### PR TITLE
Add name of profile so secondary displays can work

### DIFF
--- a/lib/oven.py
+++ b/lib/oven.py
@@ -209,6 +209,7 @@ class Oven(threading.Thread):
             'state': self.state,
             'heat': self.heat,
             'totaltime': self.totaltime,
+            'profile': self.profile.name if self.profile else None,
         }
         return state
 


### PR DESCRIPTION
I've added a small OLED display on my pi/controller so I can monitor the progress of the kiln on the kiln itself. 

This patch exposes the name of the current profile so my secondary display can respond correctly to changes made via the normal web GUI.
