### PR TITLE
Thermocouple improvements

### DIFF
--- a/config.py
+++ b/config.py
@@ -57,7 +57,7 @@ sensor_time_wait = 2
 # These parameters work well with the simulated oven. You must tune them
 # to work well with your specific kiln. Note that the integral pid_ki is
 # inverted so that a smaller number means more integral action.
-pid_kp = 25   # Proportional 
+pid_kp = 25   # Proportional
 pid_ki = 200  # Integral
 pid_kd = 200  # Derivative
 
@@ -66,11 +66,11 @@ pid_kd = 200  # Derivative
 #
 # Initial heating and Integral Windup
 #
-# During initial heating, if the temperature is constantly under the 
+# During initial heating, if the temperature is constantly under the
 # setpoint,large amounts of Integral can accumulate. This accumulation
 # causes the kiln to run above the setpoint for potentially a long
 # period of time. These settings allow integral accumulation only when
-# the temperature is within stop_integral_windup_margin percent below 
+# the temperature is within stop_integral_windup_margin percent below
 # or above the setpoint. This applies only to the integral.
 stop_integral_windup = True
 stop_integral_windup_margin = 10
@@ -96,20 +96,20 @@ sim_R_ho_air   = 0.05   # K/W  " with internal air circulation
 # If you change the temp_scale, all settings in this file are assumed to
 # be in that scale.
 
-temp_scale          = "f" # c = Celsius | f = Fahrenheit - Unit to display 
+temp_scale          = "f" # c = Celsius | f = Fahrenheit - Unit to display
 time_scale_slope    = "h" # s = Seconds | m = Minutes | h = Hours - Slope displayed in temp_scale per time_scale_slope
 time_scale_profile  = "m" # s = Seconds | m = Minutes | h = Hours - Enter and view target time in time_scale_profile
 
 # emergency shutoff the profile if this temp is reached or exceeded.
 # This just shuts off the profile. If your SSR is working, your kiln will
-# naturally cool off. If your SSR has failed/shorted/closed circuit, this 
+# naturally cool off. If your SSR has failed/shorted/closed circuit, this
 # means your kiln receives full power until your house burns down.
 # this should not replace you watching your kiln or use of a kiln-sitter
-emergency_shutoff_temp = 2264 #cone 7 
+emergency_shutoff_temp = 2264 #cone 7
 
-# If the kiln cannot heat or cool fast enough and is off by more than 
+# If the kiln cannot heat or cool fast enough and is off by more than
 # kiln_must_catch_up_max_error  the entire schedule is shifted until
-# the desired temperature is reached. If your kiln cannot attain the 
+# the desired temperature is reached. If your kiln cannot attain the
 # wanted temperature, the schedule will run forever.
 kiln_must_catch_up = True
 kiln_must_catch_up_max_error = 10 #degrees
@@ -119,3 +119,13 @@ kiln_must_catch_up_max_error = 10 #degrees
 # set set this offset to -4 to compensate.  This probably means you have a
 # cheap thermocouple.  Invest in a better thermocouple.
 thermocouple_offset=0
+
+# some kilns/thermocouples start erroneously reporting "short" errors at higher temperatures
+# due to plasma forming in the kiln.
+# Set this to False to ignore these errors and assume the temperature reading was correct anyway
+honour_theromocouple_short_errors = True
+
+# number of samples of temperature to average.
+# If you suffer from ghe high temperature kiln issue and have set honour_theromocouple_short_errors to False,
+# you will likely need to increase this (eg I use 40)
+temperature_average_samples = 5

--- a/config.py
+++ b/config.py
@@ -129,3 +129,14 @@ honour_theromocouple_short_errors = True
 # If you suffer from the high temperature kiln issue and have set honour_theromocouple_short_errors to False,
 # you will likely need to increase this (eg I use 40)
 temperature_average_samples = 5
+
+# Thermocouple AC frequency filtering - set to True if in a 50Hz locale, else leave at False for 60Hz locale
+ac_freq_50hz = False
+
+# MAX31856 avgsel -- number of samples averaged on-chip prior to returning result. Values:
+# 0: 1 sample
+# 1: 2 samples
+# 2: 4 samples
+# 3: 8 samples
+# 4: 16 samples
+max31856_avgsel = 0

--- a/config.py
+++ b/config.py
@@ -126,6 +126,6 @@ thermocouple_offset=0
 honour_theromocouple_short_errors = True
 
 # number of samples of temperature to average.
-# If you suffer from ghe high temperature kiln issue and have set honour_theromocouple_short_errors to False,
+# If you suffer from the high temperature kiln issue and have set honour_theromocouple_short_errors to False,
 # you will likely need to increase this (eg I use 40)
 temperature_average_samples = 5

--- a/config.py
+++ b/config.py
@@ -132,11 +132,3 @@ temperature_average_samples = 5
 
 # Thermocouple AC frequency filtering - set to True if in a 50Hz locale, else leave at False for 60Hz locale
 ac_freq_50hz = False
-
-# MAX31856 avgsel -- number of samples averaged on-chip prior to returning result. Values:
-# 0: 1 sample
-# 1: 2 samples
-# 2: 4 samples
-# 3: 8 samples
-# 4: 16 samples
-max31856_avgsel = 0

--- a/lib/max31855.py
+++ b/lib/max31855.py
@@ -13,7 +13,7 @@ class MAX31855(object):
         '''Initialize Soft (Bitbang) SPI bus
 
         Parameters:
-        - cs_pin:    Chip Select (CS) / Slave Select (SS) pin (Any GPIO)  
+        - cs_pin:    Chip Select (CS) / Slave Select (SS) pin (Any GPIO)
         - clock_pin: Clock (SCLK / SCK) pin (Any GPIO)
         - data_pin:  Data input (SO / MOSI) pin (Any GPIO)
         - units:     (optional) unit of measurement to return. ("c" (default) | "k" | "f")
@@ -26,6 +26,7 @@ class MAX31855(object):
         self.units = units
         self.data = None
         self.board = board
+        self.noConnection = self.shortToGround = self.shortToVCC = False
 
         # Initialize needed GPIO
         GPIO.setmode(self.board)
@@ -70,20 +71,12 @@ class MAX31855(object):
         if data_32 is None:
             data_32 = self.data
         anyErrors = (data_32 & 0x10000) != 0    # Fault bit, D16
-        noConnection = (data_32 & 0x00000001) != 0       # OC bit, D0
-        shortToGround = (data_32 & 0x00000002) != 0      # SCG bit, D1
-        shortToVCC = (data_32 & 0x00000004) != 0         # SCV bit, D2
         if anyErrors:
-            if noConnection:
-                raise MAX31855Error("No Connection")
-            elif shortToGround:
-                raise MAX31855Error("Thermocouple short to ground")
-            elif shortToVCC:
-                raise MAX31855Error("Thermocouple short to VCC")
-            else:
-                # Perhaps another SPI device is trying to send data?
-                # Did you remember to initialize all other SPI devices?
-                raise MAX31855Error("Unknown Error")
+            self.noConnection = (data_32 & 0x00000001) != 0       # OC bit, D0
+            self.shortToGround = (data_32 & 0x00000002) != 0      # SCG bit, D1
+            self.shortToVCC = (data_32 & 0x00000004) != 0
+        else:
+            self.noConnection = self.shortToGround = self.shortToVCC = False
 
     def data_to_tc_temperature(self, data_32 = None):
         '''Takes an integer and returns a thermocouple temperature in celsius.'''
@@ -138,7 +131,7 @@ class MAX31855(object):
         GPIO.setup(self.clock_pin, GPIO.IN)
 
     def data_to_LinearizedTempC(self, data_32 = None):
-        '''Return the NIST-linearized thermocouple temperature value in degrees 
+        '''Return the NIST-linearized thermocouple temperature value in degrees
         celsius. See https://learn.adafruit.com/calibrating-sensors/maxim-31855-linearization for more infoo.
         This code came from https://github.com/nightmechanic/FuzzypicoReflow/blob/master/lib/max31855.py
 '''

--- a/lib/max31855.py
+++ b/lib/max31855.py
@@ -26,7 +26,7 @@ class MAX31855(object):
         self.units = units
         self.data = None
         self.board = board
-        self.noConnection = self.shortToGround = self.shortToVCC = False
+        self.noConnection = self.shortToGround = self.shortToVCC = self.unknownError = False
 
         # Initialize needed GPIO
         GPIO.setmode(self.board)
@@ -74,9 +74,10 @@ class MAX31855(object):
         if anyErrors:
             self.noConnection = (data_32 & 0x00000001) != 0       # OC bit, D0
             self.shortToGround = (data_32 & 0x00000002) != 0      # SCG bit, D1
-            self.shortToVCC = (data_32 & 0x00000004) != 0
+            self.shortToVCC = (data_32 & 0x00000004) != 0         # SCV bit, D2
+            self.unknownError = not (self.noConnection | self.shortToGround | self.shortToVCC)    # Errk!
         else:
-            self.noConnection = self.shortToGround = self.shortToVCC = False
+            self.noConnection = self.shortToGround = self.shortToVCC = self.unknownError = False
 
     def data_to_tc_temperature(self, data_32 = None):
         '''Takes an integer and returns a thermocouple temperature in celsius.'''

--- a/lib/max31856.py
+++ b/lib/max31856.py
@@ -140,8 +140,8 @@ class MAX31856(object):
 
         # Setup for reading continuously with T-Type thermocouple
         self._write_register(self.MAX31856_REG_WRITE_CR0, 0)
-        self._write_register(self.MAX31856_REG_WRITE_CR0, self.cr0)
         self._write_register(self.MAX31856_REG_WRITE_CR1, self.cr1)
+        self._write_register(self.MAX31856_REG_WRITE_CR0, self.cr0)
 
     @staticmethod
     def _cj_temp_from_bytes(msb, lsb):

--- a/lib/max31856.py
+++ b/lib/max31856.py
@@ -89,12 +89,7 @@ class MAX31856(object):
     MAX31856_S_TYPE = 0x6 # Read S Type Thermocouple
     MAX31856_T_TYPE = 0x7 # Read T Type Thermocouple
 
-    MAX31856_OCDETECT_OFF = 0x00  # open circuit detection disabled
-    MAX31856_OCDETECT_1 = 0x01  # enabled every 16 conversions (Rs < 5kOhm)
-    MAX31856_OCDETECT_2 = 0x02  # enabled every 16 conversions (40kOhm < Rs > 5kOhm, time < 2ms)
-    MAX31856_OCDETECT_3 = 0x03  # enabled every 16 conversions (40kOhm < Rs > 5kOhm, time > 2ms)
-
-    def __init__(self, tc_type=MAX31856_S_TYPE, units="c", avgsel=0x0, ac_freq_50hz=False, ocdetect=0, software_spi=None, hardware_spi=None, gpio=None):
+    def __init__(self, tc_type=MAX31856_S_TYPE, units="c", avgsel=0x0, ac_freq_50hz=False, ocdetect=0x1, software_spi=None, hardware_spi=None, gpio=None):
         """
         Initialize MAX31856 device with software SPI on the specified CLK,
         CS, and DO pins.  Alternatively can specify hardware SPI by sending an
@@ -106,6 +101,7 @@ class MAX31856(object):
             avgsel (1-byte Hex): Type of Averaging.  Choose from values in CR0 table of datasheet.
                 Default is single sample.
             ac_freq_50hz: Set to True if your AC frequency is 50Hz, Set to False for 60Hz,
+            ocdetect: Detect open circuit errors (ie broken thermocouple). Choose from values in CR1 table of datasheet
             software_spi (dict): Contains the pin assignments for software SPI, as defined below:
                 clk (integer): Pin number for software SPI clk
                 cs (integer): Pin number for software SPI cs

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -120,7 +120,6 @@ class TempSensorReal(TempSensor):
             self.thermocouple = MAX31856(tc_type=config.thermocouple_type,
                                          software_spi = software_spi,
                                          units = config.temp_scale,
-                                         avgsel = config.max31856_avgsel,
                                          ac_freq_50hz = config.ac_freq_50hz,
                                          )
 

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -219,15 +219,11 @@ class Oven(threading.Thread):
                 log.info("kiln must catch up, too cold, shifting schedule")
                 self.start_time = self.start_time + \
                     datetime.timedelta(seconds=self.time_step)
-                return True
             # kiln too hot, wait for it to cool down
             if temp - self.target > config.kiln_must_catch_up_max_error:
                 log.info("kiln must catch up, too hot, shifting schedule")
                 self.start_time = self.start_time + \
                     datetime.timedelta(seconds=self.time_step)
-                return True
-
-        return False
 
     def update_runtime(self):
         runtime_delta = datetime.datetime.now() - self.start_time

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -96,7 +96,7 @@ class TempSensorReal(TempSensor):
        during the time_step'''
     def __init__(self):
         TempSensor.__init__(self)
-        self.sleeptime = self.time_step / float(TEMPERATURE_MOVING_AVERAGE_SAMPLES)
+        self.sleeptime = self.time_step / float(config.temperature_average_samples)
 
         if config.max31855:
             log.info("init MAX31855")
@@ -119,7 +119,7 @@ class TempSensorReal(TempSensor):
                                          )
 
     def run(self):
-        '''use a moving average of TEMPERATURE_MOVING_AVERAGE_SAMPLES across the time_step'''
+        '''use a moving average of config.temperature_average_samples across the time_step'''
         temps = []
         while True:
             temp = self.thermocouple.get()

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -120,7 +120,7 @@ class TempSensorReal(TempSensor):
                                          )
 
     def run(self):
-        '''use a moving average of TEMPERATURE_AVERAGE_WINDOW across the time_step'''
+        '''use a moving average of TEMPERATURE_MOVING_AVERAGE_SAMPLES across the time_step'''
         temps = []
         while True:
             temp = self.thermocouple.get()

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -83,8 +83,9 @@ class TempSensor(threading.Thread):
         threading.Thread.__init__(self)
         self.daemon = True
         self.temperature = 0
+        self.bad_percent = 0
         self.time_step = config.sensor_time_wait
-        self.noConnection = self.shortToGround = self.shortToVCC = False
+        self.noConnection = self.shortToGround = self.shortToVCC = self.unknownError = False
 
 class TempSensorSimulated(TempSensor):
     '''not much here, just need to be able to set the temperature'''
@@ -100,7 +101,6 @@ class TempSensorReal(TempSensor):
         self.bad_count = 0
         self.ok_count = 0
         self.bad_stamp = 0
-        self.bad_percent = 0
 
         if config.max31855:
             log.info("init MAX31855")

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -100,6 +100,7 @@ class TempSensorReal(TempSensor):
         self.bad_count = 0
         self.ok_count = 0
         self.bad_stamp = 0
+        self.bad_percent = 0
 
         if config.max31855:
             log.info("init MAX31855")
@@ -126,7 +127,8 @@ class TempSensorReal(TempSensor):
         temps = []
         while True:
             # reset error counter if time is up
-            if (time.time() - self.bad_stamp) > (self.time_step * 4):
+            if (time.time() - self.bad_stamp) > (self.time_step * 2):
+                self.bad_percent = (self.bad_count / (self.bad_count + self.ok_count)) * 100
                 self.bad_count = 0
                 self.ok_count = 0
                 self.bad_stamp = time.time()
@@ -244,7 +246,7 @@ class Oven(threading.Thread):
             log.info("emergency!!! unknown thermocouple error, shutting down")
             self.reset()
 
-        if self.board.temp_sensor.bad_count / (self.board.temp_sensor.bad_count + self.board.temp_sensor.ok_count) > 0.3:
+        if self.board.temp_sensor.bad_percent > 30:
             log.info("emergency!!! too many errors in a short period, shutting down")
             self.reset()
 

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -231,6 +231,8 @@ class Oven(threading.Thread):
             self.runtime = self.startat + runtime_delta.total_seconds()
         else:
             self.runtime = runtime_delta.total_seconds()
+        if self.runtime < 0:
+            self.runtime = 0
 
     def update_target_temp(self):
         self.target = self.profile.get_target_temperature(self.runtime)

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -128,7 +128,10 @@ class TempSensorReal(TempSensor):
         while True:
             # reset error counter if time is up
             if (time.time() - self.bad_stamp) > (self.time_step * 2):
-                self.bad_percent = (self.bad_count / (self.bad_count + self.ok_count)) * 100
+                if self.bad_count + self.ok_count:
+                    self.bad_percent = (self.bad_count / (self.bad_count + self.ok_count)) * 100
+                else:
+                    self.bad_percent = 0
                 self.bad_count = 0
                 self.ok_count = 0
                 self.bad_stamp = time.time()

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -30,10 +30,10 @@ class Output(object):
     def heat(self,sleepfor):
         self.GPIO.output(config.gpio_heat, self.GPIO.HIGH)
         time.sleep(sleepfor)
-        self.GPIO.output(config.gpio_heat, self.GPIO.LOW)
 
     def cool(self,sleepfor):
         '''no active cooling, so sleep'''
+        self.GPIO.output(config.gpio_heat, self.GPIO.LOW)
         time.sleep(sleepfor)
 
 # FIX - Board class needs to be completely removed
@@ -383,6 +383,10 @@ class RealOven(Oven):
         # start thread
         self.start()
 
+    def reset(self):
+        super().reset()
+        self.output.cool(0)
+
     def heat_then_cool(self):
         pid = self.pid.compute(self.target,
                                self.board.temp_sensor.temperature +
@@ -395,8 +399,10 @@ class RealOven(Oven):
         if heat_on > 0:
             self.heat = 1.0
 
-        self.output.heat(heat_on)
-        self.output.cool(heat_off)
+        if self.output.heat_on:
+            self.output.heat(heat_on)
+        if heat_off:
+            self.output.cool(heat_off)
         time_left = self.totaltime - self.runtime
         log.info("temp=%.2f, target=%.2f, pid=%.3f, heat_on=%.2f, heat_off=%.2f, run_time=%d, total_time=%d, time_left=%d" %
             (self.board.temp_sensor.temperature + config.thermocouple_offset,

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -118,8 +118,10 @@ class TempSensorReal(TempSensor):
                              'do': config.gpio_sensor_data,
                              'di': config.gpio_sensor_di }
             self.thermocouple = MAX31856(tc_type=config.thermocouple_type,
-                                         software_spi = sofware_spi,
-                                         units = config.temp_scale
+                                         software_spi = software_spi,
+                                         units = config.temp_scale,
+                                         avgsel = config.max31856_avgsel,
+                                         ac_freq_50hz = config.ac_freq_50hz,
                                          )
 
     def run(self):

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -399,7 +399,7 @@ class RealOven(Oven):
         if heat_on > 0:
             self.heat = 1.0
 
-        if self.output.heat_on:
+        if heat_on:
             self.output.heat(heat_on)
         if heat_off:
             self.output.cool(heat_off)

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -219,11 +219,15 @@ class Oven(threading.Thread):
                 log.info("kiln must catch up, too cold, shifting schedule")
                 self.start_time = self.start_time + \
                     datetime.timedelta(seconds=self.time_step)
+                return True
             # kiln too hot, wait for it to cool down
             if temp - self.target > config.kiln_must_catch_up_max_error:
                 log.info("kiln must catch up, too hot, shifting schedule")
                 self.start_time = self.start_time + \
                     datetime.timedelta(seconds=self.time_step)
+                return True
+
+        return False
 
     def update_runtime(self):
         runtime_delta = datetime.datetime.now() - self.start_time
@@ -279,10 +283,10 @@ class Oven(threading.Thread):
                 time.sleep(1)
                 continue
             if self.state == "RUNNING":
-                self.kiln_must_catch_up()
+                catching_up = self.kiln_must_catch_up()
                 self.update_runtime()
                 self.update_target_temp()
-                self.heat_then_cool()
+                self.heat_then_cool(catching_up)
                 self.reset_if_emergency()
                 self.reset_if_schedule_ended()
 
@@ -334,10 +338,11 @@ class SimulatedOven(Oven):
         self.temperature = self.t
         self.board.temp_sensor.temperature = self.t
 
-    def heat_then_cool(self):
+    def heat_then_cool(self, catching_up):
         pid = self.pid.compute(self.target,
                                self.board.temp_sensor.temperature +
-                               config.thermocouple_offset)
+                               config.thermocouple_offset,
+                               catching_up)
         heat_on = float(self.time_step * pid)
         heat_off = float(self.time_step * (1 - pid))
 
@@ -388,10 +393,11 @@ class RealOven(Oven):
         super().reset()
         self.output.cool(0)
 
-    def heat_then_cool(self):
+    def heat_then_cool(self, catching_up):
         pid = self.pid.compute(self.target,
                                self.board.temp_sensor.temperature +
-                               config.thermocouple_offset)
+                               config.thermocouple_offset,
+                               catching_up)
         heat_on = float(self.time_step * pid)
         heat_off = float(self.time_step * (1 - pid))
 
@@ -465,7 +471,7 @@ class PID():
     # settled on -50 to 50 and then divide by 50 at the end. This results
     # in a larger PID control window and much more accurate control...
     # instead of what used to be binary on/off control.
-    def compute(self, setpoint, ispoint):
+    def compute(self, setpoint, ispoint, catching_up):
         now = datetime.datetime.now()
         timeDelta = (now - self.lastNow).total_seconds()
 
@@ -476,7 +482,7 @@ class PID():
         if self.ki > 0:
             if config.stop_integral_windup == True:
                 margin = setpoint * config.stop_integral_windup_margin/100
-                if (abs(error) <= abs(margin)):
+                if (abs(error) <= abs(margin)) and not catching_up:
                     self.iterm += (error * timeDelta * (1/self.ki))
             else:
                 self.iterm += (error * timeDelta * (1/self.ki))

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -389,11 +389,10 @@ class RealOven(Oven):
         super().reset()
         self.output.cool(0)
 
-    def heat_then_cool(self, catching_up):
+    def heat_then_cool(self):
         pid = self.pid.compute(self.target,
                                self.board.temp_sensor.temperature +
-                               config.thermocouple_offset,
-                               catching_up)
+                               config.thermocouple_offset)
         heat_on = float(self.time_step * pid)
         heat_off = float(self.time_step * (1 - pid))
 


### PR DESCRIPTION
Hi, sorry about this deluge of patches from me, I've just been on a bit of a binge with this recently! Almost done I think/hope.

Anyway, this patch attempts to improve the thermocouple handling in various ways:

# Thermocouple errors at high temperature.

I have exactly the problem described here: https://forums.adafruit.com/viewtopic.php?f=31&t=169135#p827564

It seems to be a problem with the design of my kiln from the manufacturer. I'm wondering if its perhaps a difference between the **tiny** space in my jewellery kiln vs a ceramics kiln, but that is total speculation on my part.

When it gets above ~900C, I start getting erroneous error reports from the max31855 - most of the readings will claim there's an error, and it'll constantly flip between vcc_short and gnd_short at random (below 900 it is **totally** clean). However - as the link above says - the temperature reading still appears to be correct.

The original controller from my kiln works fine, and is handling the thermocouple using an opamp and a resistor/capacitor network: either its just ignoring the issue, or it has some circuitry not present on the max31855 that is somehow compensating. I believe it is an Orton Autofire controller.

Anyway, I can't really fix this in my hardware, so I've added the option to ignore them at runtime. However, I do realise not all kilns are the same and, so I have made the "Ignore" option something you have to actively enable.

# Abort on various errors

I've made it shut down the kiln immediately if connection to the thermocouple is lost or an unknown error is detected. I'm not sure if people occasionally see these because of glitches, so perhaps this is too draconic; If so, I can move remove it in favour of the next option:

I've also added an error threshold system. Even though I'm going to be ignoring VCC/GND errors, I thought others might appreciate this for safety reasons. It will shut down the kiln if you unexpectedly start seeing **lots** of errors in a short period. However, it should still allow the occasional glitch through (I think you mentioned you have this sometimes?).

Finally, I've made it refuse to start the kiln on any sort of thermocouple error no matter what - my assumption is if you're seeing the VCC/GND errors at room temperature, they're _really_ a problem!

# Moving average temperature and configurable sample count

This attempts to solve two issues:
* At ~920C the readings get a bit noisier (I see spikes of +- 4C reasonably frequently), which causes the PID loop problems. 
* Occasionally, the temperature and oven threads get slightly out of sync and the existing read-5-samples-and-update method  means the oven sometimes reads a temperature lagging 2 more seconds behind than normal. Not a huge problem really, but I thought I'd mention it since I happened to spot it.

So: I've switched it to a moving average updating the oven temperature every time a new sample is read, so the oven always has access to the latest (averaged) temperature.

I also added a configuration option to allow the number of averaged samples to be changed. I set the default to 5 as it is now, but I found I needed a value of about 40 to smooth out the random spikes at high temperatures.
