### PR TITLE
tweak windup so it isn't temperature dependant

### DIFF
--- a/config.py
+++ b/config.py
@@ -57,7 +57,7 @@ sensor_time_wait = 2
 # These parameters work well with the simulated oven. You must tune them
 # to work well with your specific kiln. Note that the integral pid_ki is
 # inverted so that a smaller number means more integral action.
-pid_kp = 25   # Proportional 
+pid_kp = 25   # Proportional
 pid_ki = 200  # Integral
 pid_kd = 200  # Derivative
 
@@ -66,14 +66,12 @@ pid_kd = 200  # Derivative
 #
 # Initial heating and Integral Windup
 #
-# During initial heating, if the temperature is constantly under the 
+# During initial heating, if the temperature is constantly under the
 # setpoint,large amounts of Integral can accumulate. This accumulation
 # causes the kiln to run above the setpoint for potentially a long
 # period of time. These settings allow integral accumulation only when
-# the temperature is within stop_integral_windup_margin percent below 
-# or above the setpoint. This applies only to the integral.
+# the temperature is close to the setpoint. This applies only to the integral.
 stop_integral_windup = True
-stop_integral_windup_margin = 10
 
 ########################################################################
 #
@@ -96,20 +94,20 @@ sim_R_ho_air   = 0.05   # K/W  " with internal air circulation
 # If you change the temp_scale, all settings in this file are assumed to
 # be in that scale.
 
-temp_scale          = "f" # c = Celsius | f = Fahrenheit - Unit to display 
+temp_scale          = "f" # c = Celsius | f = Fahrenheit - Unit to display
 time_scale_slope    = "h" # s = Seconds | m = Minutes | h = Hours - Slope displayed in temp_scale per time_scale_slope
 time_scale_profile  = "m" # s = Seconds | m = Minutes | h = Hours - Enter and view target time in time_scale_profile
 
 # emergency shutoff the profile if this temp is reached or exceeded.
 # This just shuts off the profile. If your SSR is working, your kiln will
-# naturally cool off. If your SSR has failed/shorted/closed circuit, this 
+# naturally cool off. If your SSR has failed/shorted/closed circuit, this
 # means your kiln receives full power until your house burns down.
 # this should not replace you watching your kiln or use of a kiln-sitter
-emergency_shutoff_temp = 2264 #cone 7 
+emergency_shutoff_temp = 2264 #cone 7
 
-# If the kiln cannot heat or cool fast enough and is off by more than 
+# If the kiln cannot heat or cool fast enough and is off by more than
 # kiln_must_catch_up_max_error  the entire schedule is shifted until
-# the desired temperature is reached. If your kiln cannot attain the 
+# the desired temperature is reached. If your kiln cannot attain the
 # wanted temperature, the schedule will run forever.
 kiln_must_catch_up = True
 kiln_must_catch_up_max_error = 10 #degrees

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -411,7 +411,7 @@ class PID():
 
         if self.ki > 0:
             if config.stop_integral_windup == True:
-                if self.kp * error < window_size:
+                if abs(self.kp * error) < window_size:
                     self.iterm += (error * timeDelta * (1/self.ki))
             else:
                 self.iterm += (error * timeDelta * (1/self.ki))

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -54,7 +54,7 @@ class Board(object):
                 self.active = True
                 log.info("import %s " % (self.name))
             except ImportError:
-                msg = "max31855 config set, but import failed" 
+                msg = "max31855 config set, but import failed"
                 log.warning(msg)
 
         if config.max31856:
@@ -64,7 +64,7 @@ class Board(object):
                 self.active = True
                 log.info("import %s " % (self.name))
             except ImportError:
-                msg = "max31856 config set, but import failed" 
+                msg = "max31856 config set, but import failed"
                 log.warning(msg)
 
     def create_temp_sensor(self):
@@ -76,7 +76,7 @@ class Board(object):
 class BoardSimulated(object):
     def __init__(self):
         self.temp_sensor = TempSensorSimulated()
- 
+
 class TempSensor(threading.Thread):
     def __init__(self):
         threading.Thread.__init__(self)
@@ -118,7 +118,7 @@ class TempSensorReal(TempSensor):
         '''take 5 measurements over each time period and return the
         average'''
         while True:
-            maxtries = 5 
+            maxtries = 5
             sleeptime = self.time_step / float(maxtries)
             temps = []
             for x in range(0,maxtries):
@@ -246,10 +246,10 @@ class SimulatedOven(Oven):
         # set temps to the temp of the surrounding environment
         self.t = self.t_env # deg C temp of oven
         self.t_h = self.t_env #deg C temp of heating element
-        
+
         # call parent init
         Oven.__init__(self)
-        
+
         # start thread
         self.start()
         log.info("SimulatedOven started")
@@ -307,9 +307,9 @@ class SimulatedOven(Oven):
              self.runtime,
              self.totaltime,
              time_left))
-        
+
         # we don't actually spend time heating & cooling during
-        # a simulation, so sleep. 
+        # a simulation, so sleep.
         time.sleep(self.time_step)
 
 
@@ -397,7 +397,7 @@ class PID():
         self.lastErr = 0
 
     # FIX - this was using a really small window where the PID control
-    # takes effect from -1 to 1. I changed this to various numbers and 
+    # takes effect from -1 to 1. I changed this to various numbers and
     # settled on -50 to 50 and then divide by 50 at the end. This results
     # in a larger PID control window and much more accurate control...
     # instead of what used to be binary on/off control.
@@ -411,12 +411,11 @@ class PID():
 
         if self.ki > 0:
             if config.stop_integral_windup == True:
-                margin = setpoint * config.stop_integral_windup_margin/100
-                if (abs(error) <= abs(margin)):
+                if self.kp * error < window_size:
                     self.iterm += (error * timeDelta * (1/self.ki))
             else:
                 self.iterm += (error * timeDelta * (1/self.ki))
-        
+
         dErr = (error - self.lastErr) / timeDelta
         output = self.kp * error + self.iterm + self.kd * dErr
         out4logs = output
@@ -430,14 +429,14 @@ class PID():
 
         output = float(output / window_size)
 
-        if out4logs > 0:        
+        if out4logs > 0:
 #            log.info("pid percents pid=%0.2f p=%0.2f i=%0.2f d=%0.2f" % (out4logs,
-#                ((self.kp * error)/out4logs)*100, 
+#                ((self.kp * error)/out4logs)*100,
 #                (self.iterm/out4logs)*100,
-#                ((self.kd * dErr)/out4logs)*100)) 
+#                ((self.kd * dErr)/out4logs)*100))
             log.info("pid actuals pid=%0.2f p=%0.2f i=%0.2f d=%0.2f" % (out4logs,
-                self.kp * error, 
+                self.kp * error,
                 self.iterm,
-                self.kd * dErr)) 
+                self.kd * dErr))
 
         return output


### PR DESCRIPTION
Hi, I started trying out the windup code with my PMC copper clay testing... it didn't quite work right. The issue here is I need to fire the kiln up to 920C, then quickly open the door and place a piece inside. This is quite normal for jewelry kilns.

Because the integral windup protection depends on the percent temperature, this means it works less well the higher the temperature. The symptom I found was that as soon as I had opened/closed the door, the temperature started to shoot up hugely. Because I was ramping to 920, the integral term could still become unreasonably large.

I modified the code so that instead of having the additional percent parameter, it simply checks that `Kp * error < window_size`. The assumption is that if the P term would saturate the pid controller, then you're not close enough to the setpoint that the integral term should be updated. This now works consistently well for me.
