### PR TITLE
fix tuner heat()/cool() calls

### DIFF
--- a/kiln-tuner.py
+++ b/kiln-tuner.py
@@ -46,7 +46,7 @@ def recordprofile(csvfile, targettemp):
     try:
         stage = 'heating'
         if not config.simulate:
-            oven.output.heat(1, tuning=True)
+            oven.output.heat(0)
 
         while True:
             temp = oven.board.temp_sensor.temperature + \
@@ -73,7 +73,7 @@ def recordprofile(csvfile, targettemp):
     finally:
         # ensure we always shut the oven down!
         if not config.simulate:
-            oven.output.heat(0)
+            oven.output.cool(0)
 
 
 def line(a, b, x):

--- a/kiln-tuner.py
+++ b/kiln-tuner.py
@@ -58,7 +58,7 @@ def recordprofile(csvfile, targettemp):
             if stage == 'heating':
                 if temp >= targettemp:
                     if not config.simulate:
-                        oven.output.heat(0)
+                        oven.output.cool(0)
                     stage = 'cooling'
 
             elif stage == 'cooling':

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -27,10 +27,8 @@ class Output(object):
             log.warning(msg)
             self.active = False
 
-    def heat(self,sleepfor, tuning=False):
+    def heat(self,sleepfor):
         self.GPIO.output(config.gpio_heat, self.GPIO.HIGH)
-        if tuning:
-            return
         time.sleep(sleepfor)
 
     def cool(self,sleepfor):


### PR DESCRIPTION
Made it use cool() to turn off the heating during tuning. I think I had so many different patches previously they didn't quite all work together!

Also, the `tuning` parameter to heat() isn't necessary any more now you can call heat() and cool() separately.
