### PR TITLE
Add ability to schedule when the kiln starts

### DIFF
--- a/kiln-controller.py
+++ b/kiln-controller.py
@@ -4,6 +4,7 @@ import os
 import sys
 import logging
 import json
+from datetime import datetime
 
 import bottle
 import gevent
@@ -60,7 +61,7 @@ def handle_api():
 
         # start at a specific minute in the schedule
         # for restarting and skipping over early parts of a schedule
-        startat = 0;      
+        startat = 0
         if 'startat' in bottle.request.json:
             startat = bottle.request.json['startat']
 
@@ -72,8 +73,7 @@ def handle_api():
         # FIXME juggling of json should happen in the Profile class
         profile_json = json.dumps(profile)
         profile = Profile(profile_json)
-        oven.run_profile(profile,startat=startat)
-        ovenWatcher.record(profile)
+        run_profile(profile,startat=startat)
 
     if bottle.request.json['cmd'] == 'stop':
         log.info("api stop command received")
@@ -95,6 +95,11 @@ def find_profile(wanted):
         if profile['name'] == wanted:
             return profile
     return None
+
+def run_profile(profile, startat=0):
+    oven.run_profile(profile, startat)
+    ovenWatcher.record(profile)
+
 
 @app.route('/picoreflow/:filename#.*#')
 def send_static(filename):
@@ -126,8 +131,26 @@ def handle_control():
                     if profile_obj:
                         profile_json = json.dumps(profile_obj)
                         profile = Profile(profile_json)
-                    oven.run_profile(profile)
-                    ovenWatcher.record(profile)
+
+                    run_profile(profile)
+
+                elif msgdict.get("cmd") == "SCHEDULED_RUN":
+                    log.info("SCHEDULED_RUN command received")
+                    scheduled_start_time = msgdict.get('scheduledStartTime')
+                    profile_obj = msgdict.get('profile')
+                    if profile_obj:
+                        profile_json = json.dumps(profile_obj)
+                        profile = Profile(profile_json)
+
+                    start_datetime = datetime.fromisoformat(
+                        scheduled_start_time,
+                    )
+                    oven.scheduled_run(
+                        start_datetime,
+                        profile,
+                        lambda: ovenWatcher.record(profile),
+                    )
+
                 elif msgdict.get("cmd") == "SIMULATE":
                     log.info("SIMULATE command received")
                     #profile_obj = msgdict.get('profile')
@@ -260,7 +283,7 @@ def get_config():
         "time_scale_slope": config.time_scale_slope,
         "time_scale_profile": config.time_scale_profile,
         "kwh_rate": config.kwh_rate,
-        "currency_type": config.currency_type})    
+        "currency_type": config.currency_type})
 
 
 def main():

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -6,6 +6,8 @@ import logging
 import json
 import config
 
+from threading import Timer
+
 log = logging.getLogger(__name__)
 
 
@@ -169,10 +171,16 @@ class Oven(threading.Thread):
         self.daemon = True
         self.temperature = 0
         self.time_step = config.sensor_time_wait
+        self.scheduled_run_timer = None
+        self.start_datetime = None
         self.reset()
 
     def reset(self):
         self.state = "IDLE"
+        if self.scheduled_run_timer and self.scheduled_run_timer.is_alive():
+            log.info("Cancelling previously scheduled run")
+            self.scheduled_run_timer.cancel()
+            self.start_datetime = None
         self.profile = None
         self.start_time = 0
         self.runtime = 0
@@ -204,6 +212,32 @@ class Oven(threading.Thread):
         self.start_time = datetime.datetime.now()
         self.startat = startat * 60
         log.info("Starting")
+
+    def scheduled_run(self, start_datetime, profile, run_trigger, startat=0):
+        self.reset()
+        seconds_until_start = (
+            start_datetime - datetime.datetime.now()
+        ).total_seconds()
+        if seconds_until_start <= 0:
+            return
+
+        self.state = "SCHEDULED"
+        self.start_datetime = start_datetime
+        self.scheduled_run_timer = Timer(
+            seconds_until_start,
+            self._timeout,
+            args=[profile, run_trigger, startat],
+        )
+        self.scheduled_run_timer.start()
+        log.info(
+            "Scheduled to run the kiln at %s",
+            self.start_datetime,
+        )
+
+    def _timeout(self, profile, run_trigger, startat):
+        self.run_profile(profile, startat)
+        if run_trigger:
+            run_trigger()
 
     def abort_run(self):
         self.reset()
@@ -263,6 +297,9 @@ class Oven(threading.Thread):
             self.reset()
 
     def get_state(self):
+        scheduled_start = None
+        if self.start_datetime:
+            scheduled_start = self.start_datetime.strftime("%Y-%m-%d %H:%M")
         state = {
             'runtime': self.runtime,
             'temperature': self.board.temp_sensor.temperature + config.thermocouple_offset,
@@ -274,6 +311,7 @@ class Oven(threading.Thread):
             'currency_type': config.currency_type,
             'profile': self.profile.name if self.profile else None,
             'pidstats': self.pid.pidstats,
+            'scheduled_start': scheduled_start,
         }
         return state
 
@@ -294,7 +332,8 @@ class Oven(threading.Thread):
 class SimulatedOven(Oven):
 
     def __init__(self):
-        self.reset()
+        # call parent init
+        Oven.__init__(self)
         self.board = BoardSimulated()
 
         self.t_env = config.sim_t_env
@@ -308,9 +347,6 @@ class SimulatedOven(Oven):
         # set temps to the temp of the surrounding environment
         self.t = self.t_env # deg C temp of oven
         self.t_h = self.t_env #deg C temp of heating element
-
-        # call parent init
-        Oven.__init__(self)
 
         # start thread
         self.start()
@@ -380,10 +416,10 @@ class RealOven(Oven):
     def __init__(self):
         self.board = Board()
         self.output = Output()
-        self.reset()
-
         # call parent init
         Oven.__init__(self)
+
+        self.reset()
 
         # start thread
         self.start()

--- a/public/assets/css/picoreflow.css
+++ b/public/assets/css/picoreflow.css
@@ -32,6 +32,11 @@ body {
     box-shadow: 0 0 1.1em 0 rgba(0,0,0,0.55);
 }
 
+#schedule-status {
+    width: auto;
+    padding-right: 4px;
+}
+
 .display {
     display: inline-block;
     text-align: right;
@@ -173,6 +178,23 @@ body {
     background: -o-radial-gradient(center, ellipse cover, rgba(221,221,221,1) 0%,rgba(221,221,221,0.26) 100%); /* Opera 12+ */
     background: -ms-radial-gradient(center, ellipse cover, rgba(221,221,221,1) 0%,rgba(221,221,221,0.26) 100%); /* IE10+ */
     background: radial-gradient(ellipse at center, rgba(221,221,221,1) 0%,rgba(221,221,221,0.26) 100%); /* W3C */
+}
+
+.ds-led-timer-active {
+    color: rgb(74, 159, 255);
+    animation: blinker 1s linear infinite;
+    background: -moz-radial-gradient(center, ellipse cover, rgba(124,197,239,1) 0%, rgba(48,144,209,0.26) 100%); /* FF3.6+ */
+    background: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(0%,rgba(124,197,239,1)), color-stop(100%,rgba(48,144,209,0.26))); /* Chrome,Safari4+ */
+    background: -webkit-radial-gradient(center, ellipse cover, rgba(124,197,239,1) 0%,rgba(48,144,209,0.26) 100%); /* Chrome10+,Safari5.1+ */
+    background: -o-radial-gradient(center, ellipse cover, rgba(124,197,239,1) 0%,rgba(48,144,209,0.26) 100%); /* Opera 12+ */
+    background: -ms-radial-gradient(center, ellipse cover, rgba(124,197,239,1) 0%,rgba(48,144,209,0.26) 100%); /* IE10+ */
+    background: radial-gradient(ellipse at center, rgba(124,197,239,1) 0%,rgba(48,144,209,0.26) 100%); /* W3C */
+}
+
+@keyframes blinker {
+  50% {
+    opacity: 0;
+  }
 }
 
 .ds-trend {
@@ -350,6 +372,17 @@ body {
 
 .modal.fade.in {
     top: 10%;
+}
+
+.schedule-group {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 10px;
+}
+
+.schedule-group > input {
+    margin-right: 5px;
+    text-align: right;
 }
 
 .alert {

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
    <div class="ds-title-panel">
     <div class="ds-title">Sensor Temp</div>
     <div class="ds-title">Target Temp</div>
+    <div id="schedule-status" class="ds-title"></div>
     <div class="ds-title ds-state pull-right" style="border-left: 1px solid #ccc;">Status</div>
    </div>
    <div class="clearfix"></div>
@@ -36,7 +37,7 @@
     <div class="display ds-num"><span id="act_temp">25</span><span class="ds-unit" id="act_temp_scale" >&deg;C</span></div>
     <div class="display ds-num ds-target"><span id="target_temp">---</span><span class="ds-unit" id="target_temp_scale">&deg;C</span></div>
     <div class="display ds-num ds-text" id="state"></div>
-    <div class="display pull-right ds-state" style="padding-right:0"><span class="ds-led" id="heat">&#92;</span><span class="ds-led" id="cool">&#108;</span><span class="ds-led" id="air">&#91;</span><span class="ds-led" id="hazard">&#73;</span><span class="ds-led" id="door">&#9832;</span></div>
+    <div class="display pull-right ds-state" style="padding-right:0"><span class="ds-led" id="heat">&#92;</span><span class="ds-led" id="cool">&#108;</span><span class="ds-led" id="air">&#91;</span><span class="ds-led" id="hazard">&#73;</span><span class="ds-led" id="timer">&#x29D6;</span></div>
    </div>
    <div class="clearfix"></div>
    <div>
@@ -107,7 +108,11 @@
     <div class="modal-footer">
      <div class="btn-group" style="width: 100%">
       <button type="button" class="btn btn-danger" style="width: 50%" data-dismiss="modal">No, take me back</button>
-      <button type="button" class="btn btn-success" style="width: 50%" data-dismiss="modal" onclick="runTask()">Yes, start the Run</button>
+      <button type="button" class="btn btn-success" style="width: 50%" data-dismiss="modal" onclick="runTask()">Yes, start the Run now</button>
+     </div>
+     <div class="schedule-group">
+       <input type="datetime-local" id="scheduled-run-time">
+       <button type="button" class="btn btn-primary" style="width: 50%" data-dismiss="modal" onclick="scheduleTask()">Schedule start for later</button>
      </div>
     </div>
    </div>


### PR DESCRIPTION
@jbruce12000 I implemented this PR in cooperation with my friend @marktilles who had this idea for the delayed start of the kiln and has been in contact with you previously. What follows is the description of this implementation.

This PR adds the possibility to use a datepicker in the modal after clicking the start button to **schedule when the kiln should start running** by itself automatically followed by clicking the newly created appropriate button.

<img width="1436" alt="Screenshot 2021-12-17 at 22 33 04" src="https://user-images.githubusercontent.com/28920027/146615911-991ee5b3-2177-49a8-84d7-176df5986ca2.png">

The timer is implemented in the backend and the start is triggered there so closing or refreshing the browser does not stop it.

When the kiln start gets scheduled, the frontend state changes so that the glowing timer icon is now shown instead of the
previously unused door icon (hope that's ok). The state is also displayed as SCHEDULED and above it the info states when it's due to start: "Start at: ..."

<img width="1431" alt="Screenshot 2021-12-17 at 22 33 26" src="https://user-images.githubusercontent.com/28920027/146616019-198443c4-e3bd-47d7-9d55-8d612346a4cd.png">

Now this state is shown whenever the page is opened in the browser until the kiln starts running. To cancel the scheduled run, one just needs to click the "Stop" button in the same way as when stopping the running kiln.

Would appreciate if you and anyone else could review and test this. Any feedback is welcome and I can make changes as needed.