### PR TITLE
Emergency shutoff

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,6 +32,13 @@ currency_type   = "$"   # Currency Symbol to show when calculating cost to run j
 gpio_heat = 23  # Switches zero-cross solid-state-relay
 gpio_e_relay = 27 # pin 13; emergency cutoff relay
 
+#   Note: `gpio_e_relay` is used to and a redundant mechanical relay in series with
+#   the SSR. Because SSRs normally fail closed (i.e. energized), this provides a 
+#   way for the controller to shut off the kiln in the event that the SSR fails.
+#   It is designed to be used with the SSR input connected to the safety relay's
+#   Normally Open (NC) output; thus, the kiln can only heat when the RPi has
+#   energized the safety relay. 
+
 ### Thermocouple Adapter selection:
 #   max31855 - bitbang SPI interface
 #   max31856 - bitbang SPI interface. must specify thermocouple_type.

--- a/config.py
+++ b/config.py
@@ -30,6 +30,7 @@ currency_type   = "$"   # Currency Symbol to show when calculating cost to run j
 
 ### Outputs
 gpio_heat = 23  # Switches zero-cross solid-state-relay
+gpio_e_relay = 27 # pin 13; emergency cutoff relay
 
 ### Thermocouple Adapter selection:
 #   max31855 - bitbang SPI interface

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -20,12 +20,21 @@ class Output(object):
             GPIO.setmode(GPIO.BCM)
             GPIO.setwarnings(False)
             GPIO.setup(config.gpio_heat, GPIO.OUT)
+            GPIO.setup(config.gpio_e_relay, GPIO.OUT)
             self.active = True
             self.GPIO = GPIO
         except:
             msg = "Could not initialize GPIOs, oven operation will only be simulated!"
             log.warning(msg)
             self.active = False
+
+    def safety_off(self):
+        '''Energizes the safety relay'''
+        self.GPIO.output(config.gpio_e_relay, self.GPIO.HIGH)
+
+    def safety_on(self):
+        '''Deenergizes the safety relay'''
+        self.GPIO.output(config.gpio_e_relay, self.GPIO.LOW)
 
     def heat(self,sleepfor):
         self.GPIO.output(config.gpio_heat, self.GPIO.HIGH)
@@ -384,12 +393,14 @@ class RealOven(Oven):
 
         # call parent init
         Oven.__init__(self)
+        self.output.safety_off()
 
         # start thread
         self.start()
 
     def reset(self):
         super().reset()
+        self.output.safety_on()
         self.output.cool(0)
 
     def heat_then_cool(self):


### PR DESCRIPTION
Addresses issue #17 by adding functionality for an in-line mechanical safety relay. 

The safety relay is energized (`self.output.safety_off()`) upon initialization of the `RealOven` class. The `RealOven.reset` method adds a call to `self.output.safety_on()` to de-energize the safety relay if `reset` is called.