### PR TITLE
Blinka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ thumbs.db
 #config.py
 .idea/*
 state.json
+venv/*

--- a/config.py
+++ b/config.py
@@ -60,10 +60,11 @@ except NotImplementedError:
 ### Thermocouple Adapter selection:
 #   max31855 - bitbang SPI interface
 #   max31856 - bitbang SPI interface. must specify thermocouple_type.
-max31855 = 1
-max31856 = 0
-# uncomment this if using MAX-31856
-#thermocouple_type = ThermocoupleType.S
+max31855 = 0
+max31856 = 1
+# uncomment these two lines if using MAX-31856
+import adafruit_max31856
+thermocouple_type = adafruit_max31856.ThermocoupleType.K
 
 # here are the possible max-31856 thermocouple types
 #   ThermocoupleType.B
@@ -115,7 +116,7 @@ stop_integral_windup = True
 ########################################################################
 #
 #   Simulation parameters
-simulate = True
+simulate = False
 sim_t_env      = 255   # deg C
 sim_c_heat     = 500.0  # J/K  heat capacity of heat element
 sim_c_oven     = 5000.0 # J/K  heat capacity of oven

--- a/kiln-controller.py
+++ b/kiln-controller.py
@@ -14,9 +14,7 @@ from geventwebsocket.handler import WebSocketHandler
 from geventwebsocket import WebSocketError
 
 try:
-    sys.dont_write_bytecode = True
     import config
-    sys.dont_write_bytecode = False
 except:
     print ("Could not import config file.")
     print ("Copy config.py.EXAMPLE to config.py and adapt it for your setup.")

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -289,12 +289,12 @@ class Max31856(TempSensorReal):
         TempSensorReal.__init__(self)
         log.info("thermocouple MAX31856")
         import adafruit_max31856
-        adafruit_max31856.ThermocoupleType(config.thermocouple_type)
-        self.thermocouple = adafruit_max31856.MAX31856(self.spi,self.cs)
+        self.thermocouple = adafruit_max31856.MAX31856(self.spi,self.cs,
+                                        thermocouple_type=config.thermocouple_type)
         if (config.ac_freq_50hz == True):
-            self.thermocouple.noise_rejection(50)
+            self.thermocouple.noise_rejection = 50
         else:
-            self.thermocouple.noise_rejection(60)
+            self.thermocouple.noise_rejection = 60
 
     def raw_temp(self):
         # The underlying adafruit library does not throw exceptions
@@ -303,7 +303,7 @@ class Max31856(TempSensorReal):
         # dict for errors and raise an exception.
         # and raise Max31856_Error(message)
         temp = self.thermocouple.temperature
-        for k,v in self.thermocouple.fault:
+        for k,v in self.thermocouple.fault.items():
             if v:
                 raise Max31856_Error(k)
         return temp
@@ -641,7 +641,7 @@ class RealOven(Oven):
 
     def heat_then_cool(self):
         pid = self.pid.compute(self.target,
-                               self.board.temp_sensor.temperature +
+                               self.board.temp_sensor.temperature() +
                                config.thermocouple_offset, datetime.datetime.now())
 
         heat_on = float(self.time_step * pid)


### PR DESCRIPTION
Working with MAX31856. Tested with type K thermocouple.

I didn't like adding the import to config.py but this was the only simple way I found to access the thermocouple type. All the other ideas I have involve repeating the Adafruit code in some fashion, which will break if they change something.

I deleted the sys.dont_write_bytecode = ... lines from kiln-controller.py. I had an intermittent problem, on both the Pi and my Ubuntu computer, where they could not find the config.py file if these lines were running. I don't actually know what these do, so deleting them may be a bad idea.

