### PR TITLE
Software pins for MAX31855

### DIFF
--- a/config.py
+++ b/config.py
@@ -53,7 +53,7 @@ try:
     spi_mosi  = board.D10 #spi Microcomputer Out Serial In (not connected on MAX315855, needed on MAX315856)
     spi_miso  = board.D9  #spi Microcomputer In Serial Out
 
-    spi_cs    = board.D5  #spi Chip Select
+    spi_cs    = board.D6  #spi Chip Select
     gpio_heat = board.D23 #output that controls relay
 except NotImplementedError:
     print("not running on blinka recognized board, probably a simulation")

--- a/config.py
+++ b/config.py
@@ -32,11 +32,14 @@ currency_type   = "$"   # Currency Symbol to show when calculating cost to run j
 # temperature data from the adafruit-31855 or adafruit-31856.
 # Blinka supports many different boards. I've only tested raspberry pi.
 #
-# SPI uses 3 or 4 pins. On the raspberry pi, you MUST use predefined
-# pins. In the case of the adafruit-31855, only 3 pins are used:
+# SPI uses 3 or 4 pins. Most supported boards have predefined "hardware" SPI pins.
+# Hardware pins for the Raspberry Pi are listed below. You MUST use predefined
+# hardware pins for the adafruit-31856. The adafruit-31855 also supports software pins via bitbangio.
+# Any GPIO pins can be used. We recommend using hardware pins as they are faster, but this should nake
+# little or difference for a thrermocouple. In the case of the adafruit-31855, only 3 pins are used:
 #
 #    SPI0_SCLK = BCM pin 11 = CLK on the adafruit-31855
-#    SPI0_MOSI = BCM pin 10 = not connected
+#    SPI0_MOSI = BCM pin 10 = Needed on the adafruit-31856, not used on the 31855
 #    SPI0_MISO = BCM pin 9  = D0 on the adafruit-31855
 #   
 # plus a GPIO output to connect to CS. You can use any GPIO pin you want.
@@ -49,11 +52,10 @@ currency_type   = "$"   # Currency Symbol to show when calculating cost to run j
 # zero-cross solid-state-relay.
 try:
     import board
-    spi_sclk  = board.D22 #spi clock
+    spi_sclk  = board.D11 #spi clock
     spi_mosi  = board.D10 #spi Microcomputer Out Serial In (not connected on MAX315855, needed on MAX315856)
-    spi_miso  = board.D27  #spi Microcomputer In Serial Out
-
-    spi_cs    = board.D6  #spi Chip Select
+    spi_miso  = board.D9  #spi Microcomputer In Serial Out
+    spi_cs    = board.D5  #spi Chip Select
     gpio_heat = board.D23 #output that controls relay
 except NotImplementedError:
     print("not running on blinka recognized board, probably a simulation")

--- a/config.py
+++ b/config.py
@@ -49,9 +49,9 @@ currency_type   = "$"   # Currency Symbol to show when calculating cost to run j
 # zero-cross solid-state-relay.
 try:
     import board
-    spi_sclk  = board.D11 #spi clock
+    spi_sclk  = board.D22 #spi clock
     spi_mosi  = board.D10 #spi Microcomputer Out Serial In (not connected on MAX315855, needed on MAX315856)
-    spi_miso  = board.D9  #spi Microcomputer In Serial Out
+    spi_miso  = board.D27  #spi Microcomputer In Serial Out
 
     spi_cs    = board.D6  #spi Chip Select
     gpio_heat = board.D23 #output that controls relay

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ import busio
 #   General options
 
 ### Logging
-log_level = logging.INFO
+log_level = logging.DEBUG
 log_format = '%(asctime)s %(levelname)s %(name)s: %(message)s'
 
 ### Server

--- a/config.py
+++ b/config.py
@@ -50,8 +50,9 @@ currency_type   = "$"   # Currency Symbol to show when calculating cost to run j
 try:
     import board
     spi_sclk  = board.D11 #spi clock
-    spi_mosi  = board.D10 #spi Microcomputer Out Serial In (not connected) 
+    spi_mosi  = board.D10 #spi Microcomputer Out Serial In (not connected on MAX315855, needed on MAX315856)
     spi_miso  = board.D9  #spi Microcomputer In Serial Out
+
     spi_cs    = board.D5  #spi Chip Select
     gpio_heat = board.D23 #output that controls relay
 except NotImplementedError:
@@ -60,11 +61,11 @@ except NotImplementedError:
 ### Thermocouple Adapter selection:
 #   max31855 - bitbang SPI interface
 #   max31856 - bitbang SPI interface. must specify thermocouple_type.
-max31855 = 0
-max31856 = 1
+max31855 = 1
+max31856 = 0
 # uncomment these two lines if using MAX-31856
-import adafruit_max31856
-thermocouple_type = adafruit_max31856.ThermocoupleType.K
+# import adafruit_max31856
+# thermocouple_type = adafruit_max31856.ThermocoupleType.K
 
 # here are the possible max-31856 thermocouple types
 #   ThermocoupleType.B

--- a/config.py
+++ b/config.py
@@ -95,7 +95,6 @@ seek_start = True
 # temperature_average_samples times during and the average value is used.
 sensor_time_wait = 2
 
-
 ########################################################################
 #
 #   PID parameters
@@ -133,7 +132,6 @@ sim_R_ho_air   = 0.05   # K/W  " with internal air circulation
 # set as high as 1000 to speed simulations up by 1000 times.
 sim_speedup_factor = 1
 
-
 ########################################################################
 #
 #   Time and Temperature parameters
@@ -155,6 +153,16 @@ emergency_shutoff_temp = 2264 #cone 7
 # delay the schedule until it does back inside. This allows for heating
 # and cooling as fast as possible and not continuing until temp is reached.
 kiln_must_catch_up = True
+
+
+#######################################################################
+# Real time display option
+#
+# If kiln_must_catch_up is true the schedule is delayed (as above) and the time displayed on the
+# graph is stopped. Setting real_time_display to True increments time on the graph normally, so
+# that the display shows the actual time/temperature curve of the kiln whether the schedule is
+# waiting or not.
+real_time_display = False
 
 # This setting is required. 
 # This setting defines the window within which PID control occurs.

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ import busio
 #   General options
 
 ### Logging
-log_level = logging.DEBUG
+log_level = logging.INFO
 log_format = '%(asctime)s %(levelname)s %(name)s: %(message)s'
 
 ### Server

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -157,7 +157,7 @@ class TempSensorReal(TempSensor):
 
     def run(self):
         while True:
-            log.debug('get_temperature run on thread' + threading.current_thread().name)
+            log.debug('get_temperature run on thread: ' + threading.current_thread().name)
 
             temp = self.get_temperature()
             if temp:
@@ -379,7 +379,7 @@ class Oven(threading.Thread):
             self.heat_rate = ((temp2 - temp1) / (time2 - time1))*3600
 
     def run_profile(self, profile, startat=0, allow_seek=True):
-        log.debug('run_profile run on thread' + threading.current_thread().name)
+        log.debug('run_profile run on thread: ' + threading.current_thread().name)
         runtime = startat * 60
         if allow_seek:
             if self.state == 'IDLE':

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -129,6 +129,7 @@ class TempSensorReal(TempSensor):
         except ValueError as ex:
             if config.max31855:
                 spi = bitbangio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
+                log.info('Using software SPI.')
             else:
                 raise ex
 

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -97,6 +97,7 @@ class TempSensor(threading.Thread):
     def __init__(self):
         threading.Thread.__init__(self)
         self.daemon = True
+        self.name = 'TempSensor'
         self.time_step = config.sensor_time_wait
         self.status = ThermocoupleTracker()
 
@@ -156,6 +157,8 @@ class TempSensorReal(TempSensor):
 
     def run(self):
         while True:
+            log.debug('get_temperature run on thread' + threading.current_thread().name)
+
             temp = self.get_temperature()
             if temp:
                 self.temptracker.add(temp)
@@ -326,6 +329,7 @@ class Oven(threading.Thread):
        for either a real or simulated oven'''
     def __init__(self):
         threading.Thread.__init__(self)
+        self.name = 'Oven'
         self.daemon = True
         self.temperature = 0
         self.time_step = config.sensor_time_wait

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -7,6 +7,7 @@ import config
 import os
 import digitalio
 import busio
+import adafruit_bitbangio as bitbangio
 import statistics
 
 log = logging.getLogger(__name__)
@@ -117,8 +118,20 @@ class TempSensorReal(TempSensor):
         TempSensor.__init__(self)
         self.sleeptime = self.time_step / float(config.temperature_average_samples)
         self.temptracker = TempTracker() 
-        self.spi = busio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
+        self.spi = self.spi_setup()
         self.cs = digitalio.DigitalInOut(config.spi_cs)
+
+    def spi_setup(self):
+        spi = None
+        try:
+            spi = busio.SPI(self.config.spi_sclk, self.config.spi_mosi, self.config.spi_miso)
+        except ValueError as ex:
+            if config.max31855:
+                spi = bitbangio.SPI(self.config.spi_sclk, self.config.spi_mosi, self.config.spi_miso)
+            else:
+                raise ex
+
+        return spi
 
     def get_temperature(self):
         '''read temp from tc and convert if needed'''

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -471,9 +471,14 @@ class Oven(threading.Thread):
 
         self.set_heat_rate(self.runtime,temp)
 
+        if config.real_time_display:
+            runtime = self.plot_runtime
+        else:
+            runtime = self.runtime
+
         state = {
             'cost': self.cost,
-            'runtime': self.plot_runtime,
+            'runtime': runtime,
             'temperature': temp,
             'target': self.target,
             'state': self.state,

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -322,8 +322,10 @@ class Oven(threading.Thread):
         self.cost = 0
         self.state = "IDLE"
         self.profile = None
-        self.start_time = 0
+        self.start_time =  datetime.datetime.now()
+        self.original_start_time = self.start_time
         self.runtime = 0
+        self.plot_runtime = 0
         self.totaltime = 0
         self.target = 0
         self.heat = 0
@@ -401,12 +403,15 @@ class Oven(threading.Thread):
                 self.start_time = self.get_start_time()
 
     def update_runtime(self):
-
         runtime_delta = datetime.datetime.now() - self.start_time
+        plot_rt_delta = datetime.datetime.now() - self.original_start_time
         if runtime_delta.total_seconds() < 0:
             runtime_delta = datetime.timedelta(0)
+        if plot_rt_delta.total_seconds() < 0:
+            plot_rt_delta = datetime.timedelta(0)
 
         self.runtime = runtime_delta.total_seconds()
+        self.plot_runtime = plot_rt_delta.total_seconds()
 
     def update_target_temp(self):
         self.target = self.profile.get_target_temperature(self.runtime)
@@ -450,7 +455,7 @@ class Oven(threading.Thread):
 
         state = {
             'cost': self.cost,
-            'runtime': self.runtime,
+            'runtime': self.plot_runtime,
             'temperature': temp,
             'target': self.target,
             'state': self.state,
@@ -568,10 +573,14 @@ class SimulatedOven(Oven):
 
     def update_runtime(self):
         runtime_delta = datetime.datetime.now() - self.start_time
+        plot_rt_delta = datetime.datetime.now() - self.original_start_time
         if runtime_delta.total_seconds() < 0:
             runtime_delta = datetime.timedelta(0)
+        if plot_rt_delta.total_seconds() < 0:
+            plot_rt_delta = datetime.timedelta(0)
 
         self.runtime = runtime_delta.total_seconds() * self.speedup_factor
+        self.plot_runtime = plot_rt_delta.total_seconds() * self.speedup_factor
 
     def update_target_temp(self):
         self.target = self.profile.get_target_temperature(self.runtime)

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -124,10 +124,10 @@ class TempSensorReal(TempSensor):
     def spi_setup(self):
         spi = None
         try:
-            spi = busio.SPI(self.config.spi_sclk, self.config.spi_mosi, self.config.spi_miso)
+            spi = busio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
         except ValueError as ex:
             if config.max31855:
-                spi = bitbangio.SPI(self.config.spi_sclk, self.config.spi_mosi, self.config.spi_miso)
+                spi = bitbangio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
             else:
                 raise ex
 

--- a/test-tempsensor.py
+++ b/test-tempsensor.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python
 import config
-from digitalio import DigitalInOut
 import time
 import datetime
-# import busio
-# import adafruit_bitbangio as bitbangio
 from lib.oven import RealBoard
 import logging
 

--- a/test-tempsensor.py
+++ b/test-tempsensor.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+import config
+from digitalio import DigitalInOut
+import time
+import datetime
+# import busio
+# import adafruit_bitbangio as bitbangio
+from lib.oven import Max31855
+from lib.oven import Max31856
+
+try:
+    import board
+except NotImplementedError:
+    print("not running a recognized blinka board, exiting...")
+    import sys
+    sys.exit()
+
+########################################################################
+#
+# To test your thermocouple...
+#
+# Edit config.py and set the following in that file to match your
+# hardware setup: SPI_SCLK, SPI_MOSI, SPI_MISO, SPI_CS
+#
+# then run this script...
+# 
+# ./test-thermocouple.py
+#
+# It will output a temperature in degrees every second. Touch your
+# thermocouple to heat it up and make sure the value changes. Accuracy
+# of my thermocouple is .25C.
+########################################################################
+
+# try:
+#     spi = busio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
+# except ValueError as ex:
+#     if config.max31855: #  Try software SPI
+#         spi = bitbangio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
+#         print('Using software pins for SPI.')
+#     else:
+#         raise ex
+#
+# cs = DigitalInOut(config.spi_cs)
+# sensor = None
+
+print("\nboard: %s" % (board.board_id))
+if(config.max31855):
+    print("thermocouple: adafruit max31855")
+    sensor = Max31855()
+if(config.max31856):
+    print("thermocouple: adafruit max31856")
+    sensor = Max31856()
+
+print("SPI configured as:\n")
+print("    config.spi_sclk = %s BCM pin" % (config.spi_sclk))
+print("    config.spi_mosi = %s BCM pin" % (config.spi_mosi))
+print("    config.spi_miso = %s BCM pin" % (config.spi_miso))
+print("    config.spi_cs   = %s BCM pin\n" % (config.spi_cs))
+print("Degrees displayed in %s\n" % (config.temp_scale))
+
+
+while(True):
+   time.sleep(1)
+   temp = sensor.temperature()
+   scale = "C"
+   if config.temp_scale == "f":
+      scale ="F"
+   print("%s %0.2f%s" %(datetime.datetime.now(),temp,scale))

--- a/test-tempsensor.py
+++ b/test-tempsensor.py
@@ -5,8 +5,7 @@ import time
 import datetime
 # import busio
 # import adafruit_bitbangio as bitbangio
-from lib.oven import Max31855
-from lib.oven import Max31856
+from lib.oven import RealBoard
 
 try:
     import board
@@ -44,12 +43,10 @@ except NotImplementedError:
 # sensor = None
 
 print("\nboard: %s" % (board.board_id))
-if(config.max31855):
+if config.max31855:
     print("thermocouple: adafruit max31855")
-    sensor = Max31855()
-if(config.max31856):
+if config.max31856:
     print("thermocouple: adafruit max31856")
-    sensor = Max31856()
 
 print("SPI configured as:\n")
 print("    config.spi_sclk = %s BCM pin" % (config.spi_sclk))
@@ -58,10 +55,11 @@ print("    config.spi_miso = %s BCM pin" % (config.spi_miso))
 print("    config.spi_cs   = %s BCM pin\n" % (config.spi_cs))
 print("Degrees displayed in %s\n" % (config.temp_scale))
 
+oven_board = RealBoard()
 
-while(True):
+while True:
    time.sleep(1)
-   temp = sensor.temperature()
+   temp = oven_board.temp_sensor.temperature()
    scale = "C"
    if config.temp_scale == "f":
       scale ="F"

--- a/test-tempsensor.py
+++ b/test-tempsensor.py
@@ -9,7 +9,7 @@ from lib.oven import RealBoard
 import logging
 
 logging.basicConfig(level=config.log_level, format=config.log_format)
-log = logging.getLogger("test-tenpsensor")
+log = logging.getLogger("test-tempsensor")
 log.info("Starting Test")
 
 try:

--- a/test-tempsensor.py
+++ b/test-tempsensor.py
@@ -6,6 +6,11 @@ import datetime
 # import busio
 # import adafruit_bitbangio as bitbangio
 from lib.oven import RealBoard
+import logging
+
+logging.basicConfig(level=config.log_level, format=config.log_format)
+log = logging.getLogger("test-tenpsensor")
+log.info("Starting Test")
 
 try:
     import board

--- a/test-tempsensor.py
+++ b/test-tempsensor.py
@@ -17,31 +17,12 @@ except NotImplementedError:
 
 ########################################################################
 #
-# To test your thermocouple...
+# To test your thermocouple and the kiln-controller TempSensor code...
 #
-# Edit config.py and set the following in that file to match your
-# hardware setup: SPI_SCLK, SPI_MOSI, SPI_MISO, SPI_CS
-#
-# then run this script...
-# 
-# ./test-thermocouple.py
-#
-# It will output a temperature in degrees every second. Touch your
-# thermocouple to heat it up and make sure the value changes. Accuracy
-# of my thermocouple is .25C.
+# This code functions a lot like test-thermocouple.py but uses the
+# actual kiln-controller code instead of calling the Adafruit libraries directly.
 ########################################################################
 
-# try:
-#     spi = busio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
-# except ValueError as ex:
-#     if config.max31855: #  Try software SPI
-#         spi = bitbangio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
-#         print('Using software pins for SPI.')
-#     else:
-#         raise ex
-#
-# cs = DigitalInOut(config.spi_cs)
-# sensor = None
 
 print("\nboard: %s" % (board.board_id))
 if config.max31855:

--- a/test-thermocouple.py
+++ b/test-thermocouple.py
@@ -32,8 +32,9 @@ except NotImplementedError:
 try:
     spi = busio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
 except ValueError as ex:
-    if config.max31855: #  Try spfware SPI
+    if config.max31855: #  Try software SPI
         spi = bitbangio.SPI(config.spi_sclk, config.spi_mosi, config.spi_miso)
+        print('Using software pins for SPI.')
     else:
         raise ex
 


### PR DESCRIPTION
This works with software or hardware pins for the MAX31855. I could not get it to work with the '56. It looks like a timing issue with the reads and/or writes. I am continuing to look into this.
test-tempsensor.py functions pretty much like test-thermocouple.py but uses the real code. This provides a good test of the thermocouple reading and averaging code. test-thernocouple might be better for people to understand when testing thernocouples - maybe test-tempsensor should be in a different directory.
I added thread names and a little debug logging.
I also added real time display of the graph as an option as I like seeing the actual time vs temperature. 

I am pretty sure this is why the MAX31856 doesn't work: https://github.com/adafruit/Adafruit_CircuitPython_BitbangIO/issues/20