### PR TITLE
Add output pin inversion, update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ My controller plugs into the wall, and the kiln plugs into the controller.
 
 **WARNING** This project involves high voltages and high currents. Please make sure that anything you build conforms to local electrical codes and aligns with industry best practices.
 
+**Note:** The GPIO configuration in this schematic does not match the defaults, check [config](https://github.com/jbruce12000/kiln-controller/blob/main/config.py) and make sure the gpio pin configuration aligns with your actual connections.
+
 ![Image](https://github.com/jbruce12000/kiln-controller/blob/main/public/assets/images/schematic.png)
 
 *Note: I tried to power my ssr directly using a gpio pin, but it did not work. My ssr required 25ma to switch and rpi's gpio could only provide 16ma. YMMV.*

--- a/config.py
+++ b/config.py
@@ -84,11 +84,12 @@ currency_type   = "$"   # Currency Symbol to show when calculating cost to run j
 
 try:
     import board
-    spi_sclk  = board.D17 #spi clock
-    spi_miso  = board.D27  #spi Microcomputer In Serial Out
-    spi_cs    = board.D22  #spi Chip Select
-    spi_mosi  = board.D10 #spi Microcomputer Out Serial In (not connected) 
-    gpio_heat = board.D23 #output that controls relay
+    spi_sclk  = board.D17    #spi clock
+    spi_miso  = board.D27    #spi Microcomputer In Serial Out
+    spi_cs    = board.D22    #spi Chip Select
+    spi_mosi  = board.D10    #spi Microcomputer Out Serial In (not connected) 
+    gpio_heat = board.D23    #output that controls relay
+    gpio_heat_invert = False #invert the output state
 except (NotImplementedError,AttributeError):
     print("not running on blinka recognized board, probably a simulation")
 

--- a/docs/old-to-new.md
+++ b/docs/old-to-new.md
@@ -55,6 +55,7 @@ pip install -r ./requirements.txt
   spi_miso = board.D17
   spi_mosi = board.D10 #this one is not actually used, so set it or not
   gpio_heat = board.D23
+  gpio_heat_invert = False
 ```
 
   5. test the thermocouple board and thermocouple

--- a/gpioreadall.py
+++ b/gpioreadall.py
@@ -67,17 +67,21 @@ def pin_state(g):
         else:
             D[p] = v
 
-    if(D['fsel'] < 2): # i.e. IN or OUT
-        name = 'GPIO{}'.format(g)
+    if('fsel' in D):
+        if(D['fsel'] < 2): # i.e. IN or OUT
+            name = 'GPIO{}'.format(g)
+        else:
+            name = D['func']
+
+        mode = MODES[D['fsel']]
+        if(D['fsel'] == 0 and 'pull' in D):
+            if(D['pull'] == 'UP'):
+                mode = 'IN ^'
+            if(D['pull'] == 'DOWN'):
+                mode = 'IN v'
     else:
         name = D['func']
-
-    mode = MODES[D['fsel']]
-    if(D['fsel'] == 0 and 'pull' in D):
-        if(D['pull'] == 'UP'):
-            mode = 'IN ^'
-        if(D['pull'] == 'DOWN'):
-            mode = 'IN v'
+        mode = ''
 
     return name, mode, D['level']
 

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -36,19 +36,22 @@ class Output(object):
     state relay to turn the kiln elements on and off.
     inputs
         config.gpio_heat
+        config.gpio_heat_invert
     '''
     def __init__(self):
         self.active = False
         self.heater = digitalio.DigitalInOut(config.gpio_heat) 
         self.heater.direction = digitalio.Direction.OUTPUT 
+        self.off = config.gpio_heat_invert
+        self.on = not self.off
 
     def heat(self,sleepfor):
-        self.heater.value = True
+        self.heater.value = self.on
         time.sleep(sleepfor)
 
     def cool(self,sleepfor):
         '''no active cooling, so sleep'''
-        self.heater.value = False
+        self.heater.value = self.off
         time.sleep(sleepfor)
 
 # wrapper for blinka board

--- a/test-output.py
+++ b/test-output.py
@@ -17,7 +17,7 @@ except NotImplementedError:
 # To test your gpio output to control a relay...
 #
 # Edit config.py and set the following in that file to match your
-# hardware setup: GPIO_HEAT
+# hardware setup: gpio_heat, gpio_heat_invert
 #
 # then run this script...
 # 
@@ -31,14 +31,17 @@ except NotImplementedError:
 
 heater = digitalio.DigitalInOut(config.gpio_heat)
 heater.direction = digitalio.Direction.OUTPUT
+off = config.gpio_heat_invert
+on = not off
 
 print("\nboard: %s" % (board.board_id))
 print("heater configured as config.gpio_heat = %s BCM pin\n" % (config.gpio_heat))
+print("heater output pin configured as invert = %r\n" % (config.gpio_heat_invert))
 
 while True:
-    heater.value = True
+    heater.value = on
     print("%s heater on" % datetime.datetime.now())
     time.sleep(5)
-    heater.value = False
+    heater.value = off
     print("%s heater off" % datetime.datetime.now())
     time.sleep(5)


### PR DESCRIPTION
Some hardware configurations (different transistor types, direct drive) need the output pin value inverted from the current implementation. This patch adds a new option to invert the output value. It also fixes a few documentation issues, and fixes a parsing problem in the gpioreadall.py script (presumably on newer rpi OS versions).