### PR TITLE
Update configuration to show required pins for max31856

### DIFF
--- a/config.py
+++ b/config.py
@@ -87,7 +87,7 @@ try:
     spi_sclk  = board.D17    #spi clock
     spi_miso  = board.D27    #spi Microcomputer In Serial Out
     spi_cs    = board.D22    #spi Chip Select
-    spi_mosi  = board.D10    #spi Microcomputer Out Serial In (not connected) 
+    spi_mosi  = board.D10    #spi Microcomputer Out Serial In (not connected, however this is required for max31856 to work) 
     gpio_heat = board.D23    #output that controls relay
     gpio_heat_invert = False #invert the output state
 except (NotImplementedError,AttributeError):


### PR DESCRIPTION
For ages I couldnt get max31856 to work as I was missing the MOSI Pin which is required to set the thermocouple type. 