### PR TITLE
Modbus

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,9 +20,9 @@ listening_port = 8081
 # This is used to calculate a cost estimate before a run. It's also used
 # to produce the actual cost during a run. My kiln has three
 # elements that when my switches are set to high, consume 9460 watts.
-kwh_rate        = 0.1319  # cost per kilowatt hour per currency_type to calculate cost to run job
-kw_elements     = 9.460 # if the kiln elements are on, the wattage in kilowatts
-currency_type   = "$"   # Currency Symbol to show when calculating cost to run job
+kwh_rate        = 1.6  # cost per kilowatt hour per currency_type to calculate cost to run job
+kw_elements     = 7.3 # if the kiln elements are on, the wattage in kilowatts
+currency_type   = "kr"   # Currency Symbol to show when calculating cost to run job
 
 ########################################################################
 #
@@ -99,8 +99,17 @@ except (NotImplementedError,AttributeError):
 # There are only two breakoutboards supported. 
 #   max31855 - only supports type K thermocouples
 #   max31856 - supports many thermocouples
-max31855 = 1
+max31855 = 0
 max31856 = 0
+modbus = 1
+
+modbus_port_name = "/dev/ttyUSB0"
+modbus_slave_address = 1
+modbus_baudrate = 38400
+modbus_registernumber = 12
+modbus_decimal = 1
+
+
 # uncomment these two lines if using MAX-31856
 import adafruit_max31856
 thermocouple_type = adafruit_max31856.ThermocoupleType.K
@@ -140,9 +149,9 @@ sensor_time_wait = 2
 # well with the simulated oven. You must tune them to work well with 
 # your specific kiln. Note that the integral pid_ki is
 # inverted so that a smaller number means more integral action.
-pid_kp = 10   # Proportional 25,200,200
-pid_ki = 80   # Integral
-pid_kd = 220.83497910261562 # Derivative
+pid_kp = 9.044738632122836   # Proportional 25,200,200
+pid_ki = 14.245288572837554   # Integral
+pid_kd = 291.3421380094641 # Derivative
 
 ########################################################################
 #
@@ -155,7 +164,7 @@ stop_integral_windup = True
 ########################################################################
 #
 #   Simulation parameters
-simulate = True
+simulate = False
 sim_t_env      = 65   # deg
 sim_c_heat     = 500.0  # J/K  heat capacity of heat element
 sim_c_oven     = 5000.0 # J/K  heat capacity of oven
@@ -176,7 +185,7 @@ sim_speedup_factor = 1
 #
 # If you change the temp_scale, all settings in this file are assumed to
 # be in that scale.
-temp_scale          = "f" # c = Celsius | f = Fahrenheit - Unit to display
+temp_scale          = "c" # c = Celsius | f = Fahrenheit - Unit to display
 time_scale_slope    = "h" # s = Seconds | m = Minutes | h = Hours - Slope displayed in temp_scale per time_scale_slope
 time_scale_profile  = "m" # s = Seconds | m = Minutes | h = Hours - Enter and view target time in time_scale_profile
 

--- a/config.py
+++ b/config.py
@@ -20,9 +20,9 @@ listening_port = 8081
 # This is used to calculate a cost estimate before a run. It's also used
 # to produce the actual cost during a run. My kiln has three
 # elements that when my switches are set to high, consume 9460 watts.
-kwh_rate        = 1.6  # cost per kilowatt hour per currency_type to calculate cost to run job
-kw_elements     = 7.3 # if the kiln elements are on, the wattage in kilowatts
-currency_type   = "kr"   # Currency Symbol to show when calculating cost to run job
+kwh_rate        = 0.1319  # cost per kilowatt hour per currency_type to calculate cost to run job
+kw_elements     = 9.460 # if the kiln elements are on, the wattage in kilowatts
+currency_type   = "$"   # Currency Symbol to show when calculating cost to run job
 
 ########################################################################
 #
@@ -149,9 +149,9 @@ sensor_time_wait = 2
 # well with the simulated oven. You must tune them to work well with 
 # your specific kiln. Note that the integral pid_ki is
 # inverted so that a smaller number means more integral action.
-pid_kp = 9.044738632122836   # Proportional 25,200,200
-pid_ki = 14.245288572837554   # Integral
-pid_kd = 291.3421380094641 # Derivative
+pid_kp = 10   # Proportional 25,200,200
+pid_ki = 80   # Integral
+pid_kd = 220.83497910261562 # Derivative
 
 ########################################################################
 #
@@ -164,7 +164,7 @@ stop_integral_windup = True
 ########################################################################
 #
 #   Simulation parameters
-simulate = False
+simulate = True
 sim_t_env      = 65   # deg
 sim_c_heat     = 500.0  # J/K  heat capacity of heat element
 sim_c_oven     = 5000.0 # J/K  heat capacity of oven
@@ -185,7 +185,7 @@ sim_speedup_factor = 1
 #
 # If you change the temp_scale, all settings in this file are assumed to
 # be in that scale.
-temp_scale          = "c" # c = Celsius | f = Fahrenheit - Unit to display
+temp_scale          = "f" # c = Celsius | f = Fahrenheit - Unit to display
 time_scale_slope    = "h" # s = Seconds | m = Minutes | h = Hours - Slope displayed in temp_scale per time_scale_slope
 time_scale_profile  = "m" # s = Seconds | m = Minutes | h = Hours - Enter and view target time in time_scale_profile
 

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -83,6 +83,9 @@ class RealBoard(Board):
             return Max31855()
         if config.max31856:
             return Max31856()
+        if config.modbus:
+            return Modbus()
+
 
 class SimulatedBoard(Board):
     '''Simulated board used during simulations.
@@ -321,6 +324,40 @@ class Max31856(TempSensorReal):
         for k,v in self.thermocouple.fault.items():
             if v:
                 raise Max31856_Error(k)
+        return temp
+
+class Modbus(TempSensorReal):
+    '''each subclass expected to handle errors and get temperature'''
+    def __init__(self):
+        TempSensorReal.__init__(self)
+        log.info("thermocouple modbus")
+        import minimalmodbus
+
+        port = config.modbus_port_name
+        slave = config.modbus_slave_address
+        baudrate = config.modbus_baudrate
+        self.register = config.modbus_registernumber
+        self.decimal = config.modbus_decimal
+
+        self.instrument = minimalmodbus.Instrument(port, slave)
+        self.instrument.serial.baudrate = baudrate
+
+        """
+        if (config.ac_freq_50hz == True):
+            self.thermocouple.noise_rejection = 50
+        else:
+            self.thermocouple.noise_rejection = 60
+        """
+
+    def raw_temp(self):
+        # The underlying adafruit library does not throw exceptions
+        # for thermocouple errors. Instead, they are stored in
+        # dict named self.thermocouple.fault. Here we check that
+        # dict for errors and raise an exception.
+        # and raise Max31856_Error(message)
+
+        temp = self.instrument.read_register(self.register, self.decimal)
+
         return temp
 
 class Oven(threading.Thread):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ adafruit-circuitpython-max31856
 # for folks using sw spi (bit banging)
 adafruit-circuitpython-bitbangio
 
+# for folks using modbud input modules
+minimalmodbus
 # untested - for PT100 platinum thermocouples
 #adafruit-circuitpython-max31865
 

--- a/test-thermocouple.py
+++ b/test-thermocouple.py
@@ -58,13 +58,30 @@ if(config.max31856):
     print("thermocouple: adafruit max31856")
     sensor = adafruit_max31856.MAX31856(spi, cs)
 
+
+
 print("Degrees displayed in %s\n" % (config.temp_scale))
 
 temp = 0
 while(True):
     time.sleep(1)
     try:
-        temp = sensor.temperature
+        if(config.modbus):
+            import minimalmodbus
+
+            port = config.modbus_port_name
+            slave = config.modbus_slave_address
+            baudrate = config.modbus_baudrate
+            register = config.modbus_registernumber
+            decimal = config.modbus_decimal
+
+            instrument = minimalmodbus.Instrument(port, slave)
+            instrument.serial.baudrate = baudrate
+
+            temp = instrument.read_register(register, decimal)
+        else:
+
+            temp = sensor.temperature
         scale = "C"
         if config.temp_scale == "f":
             temp = temp * (9/5) + 32 


### PR DESCRIPTION
Added support for industrial modbus based  industrial thermocouple input modules.  This has been confirmed to solve problems associated with MAX31856 at temperatures above 900 C.  Has been tested and stable up to 1260 C.  Input module used Z-4TC. 