### PR TITLE
Add web UI scheduling for kiln runs (date/time, single schedule, status/cancel)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,3 +26,15 @@ pause a run (maintain current temperature until resume)
 resume a paused run
     
     curl -d '{"cmd":"resume"}' -H "Content-Type: application/json" -X POST http://0.0.0.0:8081/api
+
+schedule a run (date + time) (overwrites any existing scheduled run)
+
+    curl -d '{"cmd":"schedule", "profile":"cone-05-long-bisque", "date":"2026-03-28", "time":"05:00"}' -H "Content-Type: application/json" -X POST http://0.0.0.0:8081/api
+
+get scheduled run status
+
+    curl -d '{"cmd":"schedule_status"}' -H "Content-Type: application/json" -X POST http://0.0.0.0:8081/api
+
+cancel scheduled run
+
+    curl -d '{"cmd":"schedule_cancel"}' -H "Content-Type: application/json" -X POST http://0.0.0.0:8081/api

--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -3,12 +3,27 @@ Scheduling a Kiln Run
 
 Our lives are busy. Sometimes you'll want your kiln to start at a scheduled time. This is really easy to do with the **at** command. Scheduled events persist if the raspberry pi reboots.
 
+## Schedule from the Web UI
+
+If your kiln-controller version includes the scheduler UI, you can schedule runs directly in the browser:
+
+- Select a profile
+- Pick a future date and time
+- Click "Schedule"
+- The UI shows what is scheduled and allows you to cancel
+
+Notes:
+- Scheduling a new run overwrites any existing scheduled run (only one scheduled run is kept).
+- Scheduling a time in the past is rejected with an error.
+- Under the hood this uses `at` and posts to the existing `/api` endpoint.
+- You can still inspect/remove jobs via `atq` / `atrm`.
+
 ## Install the scheduler
 
 This installs and starts the **at** scheduler.
 
     sudo apt-get update
-    sudo apt-get install at
+    sudo apt-get install at curl
 
 ### Verify Time Settings
 

--- a/kiln-controller.py
+++ b/kiln-controller.py
@@ -6,10 +6,16 @@ import sys
 import logging
 import json
 
+import re
+import shutil
+import subprocess
+import shlex
+from datetime import datetime, timedelta
+
 import bottle
 import gevent
 import geventwebsocket
-#from bottle import post, get
+# from bottle import post, get
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
 from geventwebsocket import WebSocketError
@@ -28,6 +34,224 @@ profile_path = config.kiln_profiles_directory
 from oven import SimulatedOven, RealOven, Profile
 from ovenWatcher import OvenWatcher
 
+TIME_RE = re.compile(r'^([01]?\d|2[0-3]):([0-5]\d)$')
+DATE_RE = re.compile(r'^\d{4}-\d{2}-\d{2}$')
+
+# Marker to reliably find "our" at-job and prevent multiple scheduled runs.
+KC_SCHEDULE_MARKER = 'KILN_CONTROLLER_SCHEDULED_RUN_V1'
+KC_META_PREFIX = '# KC_META '
+
+
+def _require_bin(bin_name: str, install_hint: str):
+    if shutil.which(bin_name) is None:
+        return {"success": False, "error": f"Missing '{bin_name}'. Install: {install_hint}"}
+    return None
+
+
+def _list_at_job_ids():
+    # atq output typically: "<jobid>\t<date>\t<queue>\t<user>".
+    proc = subprocess.run(['atq'], text=True, capture_output=True)
+    if proc.returncode != 0:
+        # Some systems return non-zero when queue is empty; treat as empty.
+        out = (proc.stdout or '').strip() + '\n' + (proc.stderr or '').strip()
+        log.warning('atq returned %s: %s', proc.returncode, out.strip())
+        return []
+    job_ids = []
+    for line in (proc.stdout or '').splitlines():
+        parts = line.strip().split()
+        if not parts:
+            continue
+        try:
+            job_ids.append(int(parts[0]))
+        except Exception:
+            continue
+    return job_ids
+
+
+def _get_at_script(job_id: int):
+    proc = subprocess.run(['at', '-c', str(job_id)], text=True, capture_output=True)
+    if proc.returncode != 0:
+        return ''
+    return proc.stdout or ''
+
+
+def _parse_meta_from_script(script_text: str):
+    for line in script_text.splitlines():
+        if line.startswith(KC_META_PREFIX):
+            raw = line[len(KC_META_PREFIX):].strip()
+            try:
+                return json.loads(raw)
+            except Exception:
+                return None
+    return None
+
+
+def _find_scheduled_jobs():
+    """Return a list of at-job dicts that contain our marker."""
+    jobs = []
+    for jid in _list_at_job_ids():
+        script = _get_at_script(jid)
+        if KC_SCHEDULE_MARKER in script:
+            meta = _parse_meta_from_script(script) or {}
+            jobs.append({"job_id": jid, "meta": meta})
+    return jobs
+
+
+def schedule_cancel():
+    """Remove all scheduled runs that were created by this controller (marker-based)."""
+    req = _require_bin('atrm', 'sudo apt-get install at')
+    if req:
+        return req
+
+    jobs = _find_scheduled_jobs()
+    removed = []
+    errors = []
+
+    for j in jobs:
+        jid = j['job_id']
+        proc = subprocess.run(['atrm', str(jid)], text=True, capture_output=True)
+        if proc.returncode == 0:
+            removed.append(jid)
+        else:
+            out = ((proc.stdout or '') + '\n' + (proc.stderr or '')).strip()
+            errors.append({"job_id": jid, "error": out or 'atrm failed'})
+
+    return {
+        "success": (len(errors) == 0),
+        "removed": removed,
+        "removed_count": len(removed),
+        "errors": errors
+    }
+
+
+def schedule_status():
+    """Return current schedule status (there should be at most one)."""
+    jobs = _find_scheduled_jobs()
+    if not jobs:
+        return {"success": True, "scheduled": False}
+
+    # If multiple exist (e.g. manual tampering), report first and list extras.
+    primary = jobs[0]
+    meta = primary.get('meta') or {}
+
+    resp = {
+        "success": True,
+        "scheduled": True,
+        "job_id": primary.get('job_id'),
+        "profile": meta.get('profile'),
+        "scheduled_for": meta.get('scheduled_for')
+    }
+
+    if len(jobs) > 1:
+        resp['extra_jobs'] = [j.get('job_id') for j in jobs[1:]]
+
+    return resp
+
+
+def _schedule_run_at(profile_name: str, run_dt: datetime):
+    req = _require_bin('at', 'sudo apt-get install at')
+    if req:
+        return req
+    req = _require_bin('curl', 'sudo apt-get install curl')
+    if req:
+        return req
+
+    at_ts = run_dt.strftime('%Y%m%d%H%M')  # at -t YYYYMMDDhhmm (local time)
+
+    url = f'http://127.0.0.1:{config.listening_port}/api'
+    payload = json.dumps({"cmd": "run", "profile": profile_name})
+
+    meta = {
+        "profile": profile_name,
+        "scheduled_for": run_dt.strftime('%Y-%m-%d %H:%M')
+    }
+
+    # at executes a shell script read from stdin.
+    # Use printf|curl and log to /tmp for debugging.
+    payload_q = shlex.quote(payload)
+    url_q = shlex.quote(url)
+    meta_json = json.dumps(meta, separators=(',', ':'))
+
+    job_script = (
+        f"# {KC_SCHEDULE_MARKER}\n"
+        f"{KC_META_PREFIX}{meta_json}\n"
+        f"/usr/bin/printf '%s' {payload_q} | /usr/bin/curl -sS -H 'Content-Type: application/json' -X POST --data-binary @- {url_q} >>/tmp/kiln-controller-schedule.log 2>&1\n"
+    )
+
+    proc = subprocess.run(['at', '-t', at_ts], input=job_script, text=True, capture_output=True)
+    out = ((proc.stdout or '') + '\n' + (proc.stderr or '')).strip()
+
+    if proc.returncode != 0:
+        return {"success": False, "error": out or 'Failed to schedule with at'}
+
+    job_id = None
+    jm = re.search(r'\bjob\s+(\d+)\b', out)
+    if jm:
+        try:
+            job_id = int(jm.group(1))
+        except Exception:
+            job_id = None
+
+    return {
+        "success": True,
+        "profile": profile_name,
+        "scheduled_for": run_dt.strftime('%Y-%m-%d %H:%M'),
+        "job_id": job_id,
+        "at_output": out
+    }
+
+
+def schedule_set(profile_name: str, date_str: str, time_str: str):
+    """Set a scheduled run (overwrite any existing one). date_str=YYYY-MM-DD, time_str=HH:MM."""
+    date_str = (date_str or '').strip()
+    time_str = (time_str or '').strip()
+
+    if not profile_name:
+        return {"success": False, "error": "Missing profile"}
+
+    if not time_str:
+        return {"success": False, "error": "Missing time (HH:MM)"}
+
+    mt = TIME_RE.match(time_str)
+    if not mt:
+        return {"success": False, "error": "time must be HH:MM (24h), e.g. 05:00"}
+
+    if not date_str:
+        # Default: tomorrow (kept for backwards compatibility)
+        date_str = (datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d')
+
+    if not DATE_RE.match(date_str):
+        return {"success": False, "error": "date must be YYYY-MM-DD"}
+
+    try:
+        d = datetime.strptime(date_str, '%Y-%m-%d')
+    except Exception:
+        return {"success": False, "error": "Invalid date"}
+
+    hour = int(mt.group(1))
+    minute = int(mt.group(2))
+
+    run_dt = d.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+    # Past protection: do NOT auto-adjust.
+    now = datetime.now()
+    if run_dt <= now:
+        return {"success": False, "error": "Scheduled time is in the past"}
+
+    # Validate profile exists
+    profile = find_profile(profile_name)
+    if profile is None:
+        return {"success": False, "error": f"profile {profile_name} not found"}
+
+    # Overwrite protection: remove any existing scheduled run(s) first.
+    cancel_resp = schedule_cancel()
+    if cancel_resp.get('success') is False:
+        # Not fatal; but surface it.
+        log.warning('schedule_cancel had errors: %s', cancel_resp)
+
+    return _schedule_run_at(profile_name, run_dt)
+
+
 app = bottle.Bottle()
 
 if config.simulate == True:
@@ -40,19 +264,22 @@ ovenWatcher = OvenWatcher(oven)
 # this ovenwatcher is used in the oven class for restarts
 oven.set_ovenwatcher(ovenWatcher)
 
+
 @app.route('/')
 def index():
     return bottle.redirect('/picoreflow/index.html')
+
 
 @app.route('/state')
 def state():
     return bottle.redirect('/picoreflow/state.html')
 
+
 @app.get('/api/stats')
-def handle_api():
+def handle_api_stats_get():
     log.info("/api/stats command received")
-    if hasattr(oven,'pid'):
-        if hasattr(oven.pid,'pidstats'):
+    if hasattr(oven, 'pid'):
+        if hasattr(oven.pid, 'pidstats'):
             return json.dumps(oven.pid.pidstats)
 
 
@@ -60,19 +287,26 @@ def handle_api():
 def handle_api():
     log.info("/api is alive")
 
+    req = bottle.request.json or {}
+    cmd = req.get('cmd')
+    if not cmd:
+        return {"success": False, "error": "Missing cmd"}
 
     # run a kiln schedule
-    if bottle.request.json['cmd'] == 'run':
-        wanted = bottle.request.json['profile']
+    if cmd == 'run':
+        wanted = req.get('profile')
         log.info('api requested run of profile = %s' % wanted)
+
+        if not wanted:
+            return {"success": False, "error": "Missing profile"}
 
         # start at a specific minute in the schedule
         # for restarting and skipping over early parts of a schedule
-        startat = 0;      
-        if 'startat' in bottle.request.json:
-            startat = bottle.request.json['startat']
+        startat = 0
+        if 'startat' in req:
+            startat = req['startat']
 
-        #Shut off seek if start time has been set
+        # Shut off seek if start time has been set
         allow_seek = True
         if startat > 0:
             allow_seek = False
@@ -80,7 +314,7 @@ def handle_api():
         # get the wanted profile/kiln schedule
         profile = find_profile(wanted)
         if profile is None:
-            return { "success" : False, "error" : "profile %s not found" % wanted }
+            return {"success": False, "error": "profile %s not found" % wanted}
 
         # FIXME juggling of json should happen in the Profile class
         profile_json = json.dumps(profile)
@@ -88,38 +322,60 @@ def handle_api():
         oven.run_profile(profile, startat=startat, allow_seek=allow_seek)
         ovenWatcher.record(profile)
 
-    if bottle.request.json['cmd'] == 'pause':
+        return {"success": True}
+
+    if cmd == 'pause':
         log.info("api pause command received")
         oven.state = 'PAUSED'
+        return {"success": True}
 
-    if bottle.request.json['cmd'] == 'resume':
+    if cmd == 'resume':
         log.info("api resume command received")
         oven.state = 'RUNNING'
+        return {"success": True}
 
-    if bottle.request.json['cmd'] == 'stop':
+    if cmd == 'stop':
         log.info("api stop command received")
         oven.abort_run()
+        return {"success": True}
 
-    if bottle.request.json['cmd'] == 'memo':
+    if cmd == 'memo':
         log.info("api memo command received")
-        memo = bottle.request.json['memo']
+        memo = req.get('memo')
         log.info("memo=%s" % (memo))
+        return {"success": True}
+
+    # Scheduling API
+    if cmd == 'schedule':
+        wanted = req.get('profile')
+        date_str = req.get('date')
+        time_str = req.get('time')
+        log.info('api requested schedule of profile=%s date=%s time=%s' % (wanted, date_str, time_str))
+        return schedule_set(wanted, date_str, time_str)
+
+    if cmd == 'schedule_status':
+        return schedule_status()
+
+    if cmd == 'schedule_cancel':
+        return schedule_cancel()
 
     # get stats during a run
-    if bottle.request.json['cmd'] == 'stats':
+    if cmd == 'stats':
         log.info("api stats command received")
-        if hasattr(oven,'pid'):
-            if hasattr(oven.pid,'pidstats'):
+        if hasattr(oven, 'pid'):
+            if hasattr(oven.pid, 'pidstats'):
                 return json.dumps(oven.pid.pidstats)
+        return {"success": True}
 
-    return { "success" : True }
+    return {"success": False, "error": "Unknown cmd"}
+
 
 def find_profile(wanted):
     '''
     given a wanted profile name, find it and return the parsed
     json profile object or None.
     '''
-    #load all profiles from disk
+    # load all profiles from disk
     profiles = get_profiles()
     json_profiles = json.loads(profiles)
 
@@ -128,6 +384,7 @@ def find_profile(wanted):
         if profile['name'] == wanted:
             return profile
     return None
+
 
 @app.route('/picoreflow/:filename#.*#')
 def send_static(filename):
@@ -163,15 +420,15 @@ def handle_control():
                     ovenWatcher.record(profile)
                 elif msgdict.get("cmd") == "SIMULATE":
                     log.info("SIMULATE command received")
-                    #profile_obj = msgdict.get('profile')
-                    #if profile_obj:
-                    #    profile_json = json.dumps(profile_obj)
-                    #    profile = Profile(profile_json)
-                    #simulated_oven = Oven(simulate=True, time_step=0.05)
-                    #simulation_watcher = OvenWatcher(simulated_oven)
-                    #simulation_watcher.add_observer(wsock)
-                    #simulated_oven.run_profile(profile)
-                    #simulation_watcher.record(profile)
+                    # profile_obj = msgdict.get('profile')
+                    # if profile_obj:
+                    #     profile_json = json.dumps(profile_obj)
+                    #     profile = Profile(profile_json)
+                    # simulated_oven = Oven(simulate=True, time_step=0.05)
+                    # simulation_watcher = OvenWatcher(simulated_oven)
+                    # simulation_watcher.add_observer(wsock)
+                    # simulated_oven.run_profile(profile)
+                    # simulation_watcher.record(profile)
                 elif msgdict.get("cmd") == "STOP":
                     log.info("Stop command received")
                     oven.abort_run()
@@ -205,16 +462,16 @@ def handle_storage():
                 log.info("DELETE command received")
                 profile_obj = msgdict.get('profile')
                 if delete_profile(profile_obj):
-                  msgdict["resp"] = "OK"
+                    msgdict["resp"] = "OK"
                 wsock.send(json.dumps(msgdict))
-                #wsock.send(get_profiles())
+                # wsock.send(get_profiles())
             elif msgdict.get("cmd") == "PUT":
                 log.info("PUT command received")
                 profile_obj = msgdict.get('profile')
-                #force = msgdict.get('force', False)
+                # force = msgdict.get('force', False)
                 force = True
                 if profile_obj:
-                    #del msgdict["cmd"]
+                    # del msgdict["cmd"]
                     if save_profile(profile_obj, force):
                         msgdict["resp"] = "OK"
                     else:
@@ -223,7 +480,7 @@ def handle_storage():
 
                     wsock.send(json.dumps(msgdict))
                     wsock.send(get_profiles())
-            time.sleep(1) 
+            time.sleep(1)
         except WebSocketError:
             break
     log.info("websocket (storage) closed")
@@ -272,9 +529,9 @@ def get_profiles():
 
 
 def save_profile(profile, force=False):
-    profile=add_temp_units(profile)
+    profile = add_temp_units(profile)
     profile_json = json.dumps(profile)
-    filename = profile['name']+".json"
+    filename = profile['name'] + ".json"
     filepath = os.path.join(profile_path, filename)
     if not force and os.path.exists(filepath):
         log.error("Could not write, %s already exists" % filepath)
@@ -285,6 +542,7 @@ def save_profile(profile, force=False):
     log.info("Wrote %s" % filepath)
     return True
 
+
 def add_temp_units(profile):
     """
     always store the temperature in degrees c
@@ -292,53 +550,61 @@ def add_temp_units(profile):
     """
     if "temp_units" in profile:
         return profile
-    profile['temp_units']="c"
-    if config.temp_scale=="c":
+    profile['temp_units'] = "c"
+    if config.temp_scale == "c":
         return profile
-    if config.temp_scale=="f":
-        profile=convert_to_c(profile);
+    if config.temp_scale == "f":
+        profile = convert_to_c(profile)
         return profile
+
 
 def convert_to_c(profile):
-    newdata=[]
-    for (secs,temp) in profile["data"]:
-        temp = (5/9)*(temp-32)
-        newdata.append((secs,temp))
-    profile["data"]=newdata
+    newdata = []
+    for (secs, temp) in profile["data"]:
+        temp = (5 / 9) * (temp - 32)
+        newdata.append((secs, temp))
+    profile["data"] = newdata
     return profile
 
+
 def convert_to_f(profile):
-    newdata=[]
-    for (secs,temp) in profile["data"]:
-        temp = ((9/5)*temp)+32
-        newdata.append((secs,temp))
-    profile["data"]=newdata
+    newdata = []
+    for (secs, temp) in profile["data"]:
+        temp = ((9 / 5) * temp) + 32
+        newdata.append((secs, temp))
+    profile["data"] = newdata
     return profile
+
 
 def normalize_temp_units(profiles):
     normalized = []
     for profile in profiles:
         if "temp_units" in profile:
-            if config.temp_scale == "f" and profile["temp_units"] == "c": 
+            if config.temp_scale == "f" and profile["temp_units"] == "c":
                 profile = convert_to_f(profile)
                 profile["temp_units"] = "f"
         normalized.append(profile)
     return normalized
 
+
 def delete_profile(profile):
     profile_json = json.dumps(profile)
-    filename = profile['name']+".json"
+    filename = profile['name'] + ".json"
     filepath = os.path.join(profile_path, filename)
     os.remove(filepath)
     log.info("Deleted %s" % filepath)
     return True
 
+
 def get_config():
-    return json.dumps({"temp_scale": config.temp_scale,
+    return json.dumps({
+        "temp_scale": config.temp_scale,
         "time_scale_slope": config.time_scale_slope,
         "time_scale_profile": config.time_scale_profile,
         "kwh_rate": config.kwh_rate,
-        "currency_type": config.currency_type})    
+        "currency_type": config.currency_type
+    })
+
 
 def main():
     ip = "0.0.0.0"

--- a/public/assets/js/kiln-scheduler.js
+++ b/public/assets/js/kiln-scheduler.js
@@ -1,0 +1,240 @@
+/*
+  Scheduling UI glue for kiln-controller
+
+  Features:
+  - Pick date (calendar) and time
+  - Quick buttons: today / tomorrow / day after tomorrow
+  - Overwrite protection (backend deletes any existing scheduled job)
+  - Status display + cancel button
+
+  API:
+    POST /api {cmd:'schedule', profile:'<name>', date:'YYYY-MM-DD', time:'HH:MM'}
+    POST /api {cmd:'schedule_status'}
+    POST /api {cmd:'schedule_cancel'}
+
+  Requires: jQuery + jquery.bootstrap-growl (already loaded by index.html)
+*/
+
+function kcPad2(n) {
+  return (n < 10) ? ('0' + n) : String(n);
+}
+
+function kcFormatDateYYYYMMDD(d) {
+  return d.getFullYear() + '-' + kcPad2(d.getMonth() + 1) + '-' + kcPad2(d.getDate());
+}
+
+function kcGetSelectedProfileName() {
+  var prof = (typeof selected_profile_name !== 'undefined') ? selected_profile_name : null;
+  if (prof) return prof;
+
+  // Fallback if selected_profile_name is not set for some reason
+  try {
+    if (typeof profiles !== 'undefined' && typeof selected_profile !== 'undefined' && profiles[selected_profile]) {
+      return profiles[selected_profile].name;
+    }
+  } catch (e) {}
+
+  return null;
+}
+
+function kcGrowl(msg, type, width, delay) {
+  $.bootstrapGrowl(msg, {
+    ele: 'body',
+    type: type || 'info',
+    offset: {from: 'top', amount: 250},
+    align: 'center',
+    width: width || 520,
+    delay: delay || 6000,
+    allow_dismiss: true,
+    stackup_spacing: 10
+  });
+}
+
+
+function kcGetScheduleDateTimeFromInputs() {
+  var dateStr = ($('#schedule_date').val() || '').trim();
+  var timeStr = ($('#schedule_time').val() || '').trim();
+
+  if (!dateStr) return { error: 'Bitte ein Datum wählen.' };
+  if (!timeStr) return { error: 'Bitte eine Uhrzeit wählen (HH:MM).' };
+
+  var m = timeStr.match(/^([01]?\d|2[0-3]):([0-5]\d)$/);
+  if (!m) return { error: 'Uhrzeit muss HH:MM (24h) sein.' };
+
+  var parts = dateStr.split('-');
+  if (parts.length !== 3) return { error: 'Datum muss YYYY-MM-DD sein.' };
+
+  var y = parseInt(parts[0], 10);
+  var mo = parseInt(parts[1], 10) - 1;
+  var da = parseInt(parts[2], 10);
+  var hh = parseInt(m[1], 10);
+  var mm = parseInt(m[2], 10);
+
+  var dt = new Date(y, mo, da, hh, mm, 0, 0);
+  if (isNaN(dt.getTime())) return { error: 'Ungültiges Datum/Uhrzeit.' };
+
+  // Strict past protection (do not auto-adjust)
+  if (dt.getTime() <= (new Date()).getTime()) {
+    return { error: 'Der gewählte Zeitpunkt liegt in der Vergangenheit.' };
+  }
+
+  return { dateStr: dateStr, timeStr: timeStr, dt: dt };
+}
+
+function kcRenderScheduleStatus(statusResp) {
+  try {
+    if (!statusResp || statusResp.success !== true) {
+      $('#schedule_status_text').text('Schedule: Status unbekannt');
+      $('#btn_schedule_cancel').hide();
+      return;
+    }
+
+    if (!statusResp.scheduled) {
+      $('#schedule_status_text').text('Schedule: nicht gesetzt');
+      $('#btn_schedule_cancel').hide();
+      return;
+    }
+
+    var when = statusResp.scheduled_for || '(unbekannt)';
+    var prof = statusResp.profile || '(unbekanntes Profil)';
+    var job = statusResp.job_id ? (' (Job ' + statusResp.job_id + ')') : '';
+
+    $('#schedule_status_text').text('Schedule: ' + when + ' — ' + prof + job);
+    $('#btn_schedule_cancel').show();
+  } catch (e) {}
+}
+
+function kcRefreshScheduleStatus() {
+  $.ajax({
+    url: '/api',
+    type: 'POST',
+    contentType: 'application/json',
+    dataType: 'json',
+    data: JSON.stringify({ cmd: 'schedule_status' }),
+    success: function(resp) {
+      kcRenderScheduleStatus(resp);
+    },
+    error: function() {
+      kcRenderScheduleStatus({ success: false });
+    }
+  });
+}
+
+function kcCancelSchedule() {
+  try {
+    $('#btn_schedule_cancel').prop('disabled', true);
+
+    $.ajax({
+      url: '/api',
+      type: 'POST',
+      contentType: 'application/json',
+      dataType: 'json',
+      data: JSON.stringify({ cmd: 'schedule_cancel' }),
+      success: function(resp) {
+        $('#btn_schedule_cancel').prop('disabled', false);
+
+        if (!resp || resp.success !== true) {
+          var err = (resp && resp.error) ? resp.error : 'Abbrechen fehlgeschlagen.';
+          kcGrowl('ERROR: ' + err, 'error', 560, 7000);
+          kcRefreshScheduleStatus();
+          return;
+        }
+
+        var cnt = (typeof resp.removed_count !== 'undefined') ? resp.removed_count : null;
+        var msg = (cnt === null) ? 'Schedule abgebrochen.' : ('Schedule abgebrochen. Entfernte Jobs: ' + cnt);
+        kcGrowl(msg, 'success', 520, 6000);
+        kcRefreshScheduleStatus();
+      },
+      error: function(xhr) {
+        $('#btn_schedule_cancel').prop('disabled', false);
+        var txt = (xhr && xhr.responseText) ? xhr.responseText : 'Abbrechen fehlgeschlagen.';
+        kcGrowl('ERROR: ' + txt, 'error', 650, 8000);
+        kcRefreshScheduleStatus();
+      }
+    });
+  } catch (e) {
+    $('#btn_schedule_cancel').prop('disabled', false);
+    kcGrowl('ERROR: ' + String(e), 'error', 650, 8000);
+  }
+}
+
+function kcScheduleRun() {
+  try {
+    // Guardrails
+    if (typeof state !== 'undefined' && (state === 'RUNNING' || state === 'PAUSED')) {
+      kcGrowl('Kann nicht schedulen solange ein Run aktiv ist. Bitte zuerst stoppen.', 'error', 520, 6500);
+      return;
+    }
+
+    var prof = kcGetSelectedProfileName();
+    if (!prof) {
+      kcGrowl('Kein Profil ausgewählt.', 'error', 420, 6000);
+      return;
+    }
+
+    var dtInfo = kcGetScheduleDateTimeFromInputs();
+    if (dtInfo.error) {
+      kcGrowl(dtInfo.error, 'error', 520, 6500);
+      return;
+    }
+
+    var payload = { cmd: 'schedule', profile: prof, date: dtInfo.dateStr, time: dtInfo.timeStr };
+
+    $('#btn_schedule').prop('disabled', true);
+
+    $.ajax({
+      url: '/api',
+      type: 'POST',
+      contentType: 'application/json',
+      dataType: 'json',
+      data: JSON.stringify(payload),
+      success: function(resp) {
+        $('#btn_schedule').prop('disabled', false);
+
+        if (!resp || resp.success !== true) {
+          var err = (resp && resp.error) ? resp.error : 'Scheduling fehlgeschlagen.';
+          kcGrowl('ERROR: ' + err, 'error', 650, 8000);
+          kcRefreshScheduleStatus();
+          return;
+        }
+
+        var msg = 'Scheduled "' + resp.profile + '" für ' + resp.scheduled_for + '.';
+        if (resp.job_id) msg += ' Job ' + resp.job_id + '.';
+
+        kcGrowl(msg, 'success', 700, 8000);
+        kcRefreshScheduleStatus();
+      },
+      error: function(xhr) {
+        $('#btn_schedule').prop('disabled', false);
+        var txt = (xhr && xhr.responseText) ? xhr.responseText : 'Scheduling fehlgeschlagen.';
+        kcGrowl('ERROR: ' + txt, 'error', 700, 9000);
+        kcRefreshScheduleStatus();
+      }
+    });
+  } catch (e) {
+    $('#btn_schedule').prop('disabled', false);
+    kcGrowl('ERROR: ' + String(e), 'error', 650, 8000);
+  }
+}
+
+// Initialize defaults + status polling
+$(document).ready(function() {
+  try {
+    // Default date: tomorrow
+    var dd = new Date();
+    dd.setHours(0, 0, 0, 0);
+    dd.setDate(dd.getDate() + 1);
+    $('#schedule_date').val(kcFormatDateYYYYMMDD(dd));
+
+    // Default time: next full hour
+    var d = new Date();
+    d.setMinutes(0, 0, 0);
+    d.setHours(d.getHours() + 1);
+    $('#schedule_time').val(kcPad2(d.getHours()) + ':' + kcPad2(d.getMinutes()));
+
+    kcRefreshScheduleStatus();
+
+    // Keep status fresh (e.g., after reboot or once the job ran)
+    window.setInterval(kcRefreshScheduleStatus, 10000);
+  } catch (e) {}
+});

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,7 @@
  <script src="assets/js/jquery.bootstrap-growl.min.js"></script>
  <script src="assets/js/select2.min.js"></script>
  <script src="assets/js/picoreflow.js"></script>
+ <script src="assets/js/kiln-scheduler.js"></script>
 
  <link rel="stylesheet" href="assets/css/bootstrap.min.css"/>
  <link rel="stylesheet" href="assets/css/bootstrap-theme.min.css"/>
@@ -64,6 +65,21 @@
      <button type="button" class="btn btn-success" data-toggle="modal" data-target="#jobSummaryModal"><span class="glyphicon glyphicon-play"></span> Start</button>
     </div>
     <button id="nav_stop" type="button" class="btn btn-danger" onclick="abortTask()" style="display:none" ><span class="glyphicon glyphicon-stop"></span> Stop</button>
+
+    <!-- Scheduling controls (single scheduled run; overwrite protection) -->
+    <div id="nav_schedule" style="display:inline-block; margin-left: 10px; vertical-align: top;">
+     <div style="white-space: nowrap;">
+      <input id="schedule_date" type="date" class="form-control" title="Start date" style="width: 155px; display:inline-block; vertical-align: middle;"> <input id="schedule_time" type="time" class="form-control" title="Start time" style="width: 120px; display:inline-block; vertical-align: middle; margin-left: 4px;">
+      <button id="btn_schedule" type="button" class="btn btn-primary" style="vertical-align: middle; margin-left: 4px;" onclick="kcScheduleRun()">
+       <span class="glyphicon glyphicon-time"></span> Schedule
+      </button>
+      <button id="btn_schedule_cancel" type="button" class="btn btn-warning" style="vertical-align: middle; margin-left: 4px; display:none;" onclick="kcCancelSchedule()">
+       <span class="glyphicon glyphicon-remove"></span> Cancel
+      </button>
+     </div>
+     <div id="schedule_status_text" style="font-size: 12px; color: #666; margin-top: 4px;"></div>
+    </div>
+
    </div>
     <div id="edit" style="display:none;">
      <div class="input-group">


### PR DESCRIPTION
Adds a simple scheduling UI in the browser (date + time), plus API support for schedule/status/cancel
Rejects scheduling in the past
Ensures only one scheduled run exists (new schedule overwrites the previous one)
Uses at (as already documented) and posts to the existing /api endpoint
Docs updated (api.md, schedule.md) to describe the new commands and UI usage

How to test:
sudo apt-get install at curl and enable atd
Start kiln-controller
In Web UI select a profile, choose a future date/time, click Schedule
Verify status in UI and with atq
Cancel from UI and verify job removed

**Most of the implementation was created with help from ChatGPT, then tested on my side.**