### PR TITLE
Fix critical bugs: null deref, path traversal, list mutation, PID div…

### DIFF
--- a/kiln-controller.py
+++ b/kiln-controller.py
@@ -49,7 +49,7 @@ def state():
     return bottle.redirect('/picoreflow/state.html')
 
 @app.get('/api/stats')
-def handle_api():
+def handle_api_stats():
     log.info("/api/stats command received")
     if hasattr(oven,'pid'):
         if hasattr(oven.pid,'pidstats'):
@@ -159,8 +159,8 @@ def handle_control():
                     if profile_obj:
                         profile_json = json.dumps(profile_obj)
                         profile = Profile(profile_json)
-                    oven.run_profile(profile)
-                    ovenWatcher.record(profile)
+                        oven.run_profile(profile)
+                        ovenWatcher.record(profile)
                 elif msgdict.get("cmd") == "SIMULATE":
                     log.info("SIMULATE command received")
                     #profile_obj = msgdict.get('profile')
@@ -326,9 +326,11 @@ def normalize_temp_units(profiles):
     return normalized
 
 def delete_profile(profile):
-    profile_json = json.dumps(profile)
     filename = profile['name']+".json"
-    filepath = os.path.join(profile_path, filename)
+    filepath = os.path.realpath(os.path.join(profile_path, filename))
+    if not filepath.startswith(os.path.realpath(profile_path) + os.sep):
+        log.error("Rejected delete of %s: path traversal detected" % filepath)
+        return False
     os.remove(filepath)
     log.info("Deleted %s" % filepath)
     return True

--- a/kiln-tuner.py
+++ b/kiln-tuner.py
@@ -192,7 +192,7 @@ if __name__ == "__main__":
 
     csvfile = "tuning.csv"
     target = args.target_temp
-    if config.temp_scale.lower() == "c":
+    if config.temp_scale.lower() == "f":
         target = (target - 32)*5/9
     tangentdivisor = args.tangent_divisor 
 

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -159,7 +159,7 @@ class TempSensorReal(TempSensor):
     def run(self):
         while True:
             temp = self.get_temperature()
-            if temp:
+            if temp is not None:
                 self.temptracker.add(temp)
             time.sleep(self.sleeptime)
 
@@ -169,7 +169,7 @@ class TempTracker(object):
     '''
     def __init__(self):
         self.size = config.temperature_average_samples
-        self.temps = [0 for i in range(self.size)]
+        self.temps = []
   
     def add(self,temp):
         self.temps.append(temp)
@@ -177,10 +177,8 @@ class TempTracker(object):
             del self.temps[0]
 
     def get_avg_temp(self, chop=25):
-        '''
-        take the median of the given values. this used to take an avg
-        after getting rid of outliers. median works better.
-        '''
+        if not self.temps:
+            return 0
         return statistics.median(self.temps)
 
 class ThermocoupleTracker(object):
@@ -331,6 +329,7 @@ class Oven(threading.Thread):
         self.daemon = True
         self.temperature = 0
         self.time_step = config.sensor_time_wait
+        self.ovenwatcher = None
         self.reset()
 
     def reset(self):
@@ -537,11 +536,13 @@ class Oven(threading.Thread):
         self.run_profile(profile, startat=startat, allow_seek=False)  # We don't want a seek on an auto restart.
         self.cost = d["cost"]
         time.sleep(1)
-        self.ovenwatcher.record(profile)
+        if self.ovenwatcher:
+            self.ovenwatcher.record(profile)
 
     def set_ovenwatcher(self,watcher):
         log.info("ovenwatcher set in oven class")
         self.ovenwatcher = watcher
+
 
     def run(self):
         while True:
@@ -552,12 +553,9 @@ class Oven(threading.Thread):
                 time.sleep(1)
                 continue
             if self.state == "PAUSED":
-                self.start_time = self.get_start_time()
-                self.update_runtime()
-                self.update_target_temp()
-                self.heat_then_cool()
+                self.start_time = datetime.datetime.now() - datetime.timedelta(seconds=self.runtime)
                 self.reset_if_emergency()
-                self.reset_if_schedule_ended()
+                time.sleep(self.time_step)
                 continue
             if self.state == "RUNNING":
                 self.update_cost()
@@ -764,16 +762,14 @@ class Profile():
         if time > self.get_duration():
             return (None, None)
 
-        prev_point = None
-        next_point = None
-
         for i in range(len(self.data)):
-            if time < self.data[i][0]:
-                prev_point = self.data[i-1]
-                next_point = self.data[i]
-                break
+            if time <= self.data[i][0]:
+                if i == 0:
+                    return (self.data[0], self.data[1] if len(self.data) > 1 else self.data[0])
+                return (self.data[i - 1], self.data[i])
 
-        return (prev_point, next_point)
+        # time equals duration exactly — return last two points
+        return (self.data[-2], self.data[-1]) if len(self.data) >= 2 else (self.data[-1], self.data[-1])
 
     def get_target_temperature(self, time):
         if time > self.get_duration():
@@ -832,7 +828,7 @@ class PID():
         else:
             icomp = (error * timeDelta * (1/self.ki))
             self.iterm += (error * timeDelta * (1/self.ki))
-            dErr = (error - self.lastErr) / timeDelta
+            dErr = (error - self.lastErr) / timeDelta if timeDelta > 0 else 0
             output = self.kp * error + self.iterm + self.kd * dErr
             output = sorted([-1 * window_size, output, window_size])[1]
             out4logs = output

--- a/lib/ovenWatcher.py
+++ b/lib/ovenWatcher.py
@@ -80,12 +80,15 @@ class OvenWatcher(threading.Thread):
         message_json = json.dumps(message)
         log.debug("sending to %d clients: %s"%(len(self.observers),message_json))
 
+        failed = []
         for wsock in self.observers:
             if wsock:
                 try:
                     wsock.send(message_json)
                 except:
                     log.error("could not write to socket %s"%wsock)
-                    self.observers.remove(wsock)
+                    failed.append(wsock)
             else:
-                self.observers.remove(wsock)
+                failed.append(wsock)
+        for wsock in failed:
+            self.observers.remove(wsock)


### PR DESCRIPTION
…-by-zero

- oven.py: fix `if temp:` → `if temp is not None:` so 0°C readings aren't dropped
- oven.py: initialise TempTracker with empty list instead of zeros to prevent median being skewed toward 0 during warmup; guard get_avg_temp for empty list
- oven.py: fix get_surrounding_points returning (None,None) when time==0 or equals duration, causing TypeError in get_target_temperature
- oven.py: PAUSED state no longer fires heater or drifts clock; just holds start_time and sleeps
- oven.py: guard PID derivative against timeDelta==0 to prevent ZeroDivisionError
- oven.py: initialise self.ovenwatcher=None in Oven.__init__ and guard automatic_restart to avoid AttributeError race on startup
- ovenWatcher.py: collect failed sockets then remove after iteration to avoid skipping elements when mutating list during forward iteration
- kiln-controller.py: move oven.run_profile inside the `if profile_obj:` guard to prevent running stale/unbound profile
- kiln-controller.py: rename GET /api/stats handler to handle_api_stats so it is not silently overwritten by the POST /api handler
- kiln-controller.py: add path-traversal check to delete_profile using realpath
- kiln-tuner.py: fix inverted temp conversion branch (was converting when scale=="c", should be when scale=="f")

https://claude.ai/code/session_01Qx2tgAheXt9fFuDhuF6bJ4