### PR TITLE
fix #status css so it looks right on mobile

### DIFF
--- a/public/assets/css/picoreflow.css
+++ b/public/assets/css/picoreflow.css
@@ -26,7 +26,6 @@ body {
     -moz-border-radius: 7px;
     border-radius: 7px;
     border: 1px solid #ddd;
-    height: 80px;
     -moz-box-shadow: 0 0 1.1em 0 rgba(0,0,0,0.55);
     -webkit-box-shadow: 0 0 1.5em 0 rgba(0,0,0,0.55);
     box-shadow: 0 0 1.1em 0 rgba(0,0,0,0.55);


### PR DESCRIPTION
This changes fixes the lower panel overlapping the status block on narrow displays (such as a mobile phone)

Before:
<img width="429" height="833" alt="image" src="https://github.com/user-attachments/assets/6a221cff-b7c5-4439-ae4f-f06f4a12a6c3" />

After:
<img width="425" height="667" alt="image" src="https://github.com/user-attachments/assets/abfd43e3-72a8-4ce2-afb8-50fde338fb11" />


